### PR TITLE
Update decidim

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,6 @@ gem "decidim", git: "https://github.com/AjuntamentdeBarcelona/decidim.git"
 gem 'puma', '~> 3.0'
 gem 'uglifier', '>= 1.3.0'
 
-gem "foundation_rails_helper", git: "https://github.com/sgruhier/foundation_rails_helper.git", tag: "df0bd8e"
-
 group :development, :test do
   gem 'byebug', platform: :mri
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/AjuntamentdeBarcelona/decidim.git
-  revision: 35d4001a937015df5cbf7851bdfaff38b7465274
+  revision: 3eaacdb41acb91fffd1889835d6b0116fe911d16
   specs:
     decidim (0.0.1)
       decidim-admin (= 0.0.1)
@@ -21,7 +21,7 @@ GIT
       devise (~> 4.2)
       devise-i18n (~> 1.1.0)
       devise_invitable (~> 1.7.0)
-      foundation_rails_helper (~> 2.0.0)
+      foundation_rails_helper (~> 3.0.0.rc)
       jquery-rails (~> 4.2.2)
       rails (~> 5.0.0, >= 5.0.0.1)
       rectify (~> 0.8.0)
@@ -35,7 +35,6 @@ GIT
       sprockets-es6 (~> 0.9.2)
     decidim-comments (0.0.1)
       decidim-core (= 0.0.1)
-      foundation_rails_helper (~> 2.0.0)
       jquery-rails (~> 4.0)
       rails (~> 5.0.0, >= 5.0.0.1)
       turbolinks (~> 5.0.0, >= 5.0.0.1)
@@ -49,7 +48,7 @@ GIT
       devise-i18n (~> 1.1.0)
       file_validators (~> 2.1.0)
       foundation-rails (~> 6.3.0.0)
-      foundation_rails_helper (~> 2.0.0)
+      foundation_rails_helper (~> 3.0.0.rc)
       high_voltage (~> 3.0.0)
       jquery-rails (~> 4.2.2)
       mini_magick (~> 4.6.0)
@@ -85,24 +84,12 @@ GIT
       devise (~> 4.2)
       devise-i18n (~> 1.1.0)
       devise_invitable (~> 1.7.0)
-      foundation_rails_helper (~> 2.0.0)
+      foundation_rails_helper (~> 3.0.0.rc)
       jquery-rails (~> 4.2.2)
       rails (~> 5.0.0, >= 5.0.0.1)
       rectify (~> 0.8.0)
       sassc-rails (~> 1.3.0)
       turbolinks (~> 5.0.0, >= 5.0.0.1)
-
-GIT
-  remote: https://github.com/sgruhier/foundation_rails_helper.git
-  revision: df0bd8eca1b43b8bfdcb163f9e1e3b3b9ab0595e
-  tag: df0bd8e
-  specs:
-    foundation_rails_helper (2.0.0)
-      actionpack (>= 4.1)
-      activemodel (>= 4.1)
-      activesupport (>= 4.1)
-      railties (>= 4.1)
-      tzinfo (~> 1.2, >= 1.2.2)
 
 GEM
   remote: https://rubygems.org/
@@ -223,6 +210,12 @@ GEM
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
       sprockets-es6 (>= 0.9.0)
+    foundation_rails_helper (3.0.0.rc2)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      activesupport (>= 4.1)
+      railties (>= 4.1)
+      tzinfo (~> 1.2, >= 1.2.2)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     graphiql-rails (1.4.1)
@@ -394,7 +387,6 @@ DEPENDENCIES
   decidim!
   faker (~> 1.6.6)
   fog-aws
-  foundation_rails_helper!
   listen (~> 3.0.5)
   puma (~> 3.0)
   rails_12factor


### PR DESCRIPTION
#### :tophat: What? Why?
This updates decidim and makes unnessesary specifying `foundation_rails_helper` from github as a dependency.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/ZpnRYbfN0d8d2/giphy.gif)
