### PR TITLE
Add omniauth secrets configuration

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,15 +10,30 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+default: &default
+  omniauth:
+    facebook:
+      # It must be a boolean. Remember ENV variables doesn't support booleans.
+      enabled: false
+      app_id: <%%= ENV["OMNIAUTH_FACEBOOK_APP_ID"] %>
+      app_secret: <%%= ENV["OMNIAUTH_FACEBOOK_APP_SECRET"] %>
+    twitter:
+      enabled: false
+      api_key: <%%= ENV["OMNIAUTH_TWITTER_API_KEY"] %>
+      api_secret: <%%= ENV["OMNIAUTH_TWITTER_API_SECRET"] %>
+
 development:
+  <<: *default
   secret_key_base: 7e882925c6fb2300b72469aed808bab8f88a3c407466c6314b714a510f6e67467c9d7856ce85255157938f1af02d9b3c276fd1c8bfd7abde095ef778c612583a
 
 test:
+  <<: *default
   secret_key_base: d91d7fb139f8c81b34fc67b92782e9f8727681beebf26903047f0164365d8e5a6fce631d65daa3303f4a7d530b5b6521b65b30fadbd4fba2a7f9aa9347442477
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
+  <<: *default
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   sendgrid: <%= !ENV["SENDGRID_USERNAME"].blank? %>
   smtp_username: <%= ENV["SMTP_USERNAME"] || ENV["SENDGRID_USERNAME"] %>


### PR DESCRIPTION
#### :tophat: What? Why?

I added omniauth omniauth credentials to secrets. They must be defined as a env variables into the server.

#### :pushpin: Related Issues
- Related to https://github.com/AjuntamentdeBarcelona/decidim/pull/515

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
