### PR TITLE
Fix debates layout

### DIFF
--- a/engines/decidim-debates/app/views/decidim/debates/debates/index.html.erb
+++ b/engines/decidim-debates/app/views/decidim/debates/debates/index.html.erb
@@ -1,45 +1,43 @@
-<main class="wrapper">
-  <div class="row columns">
-    <div class="title-action">
-      <h2 class="title-action__title section-heading"><%= t(".open_debates") %></h2>
-      </a>
-    </div>
+<div class="row columns">
+  <div class="title-action">
+    <h2 class="title-action__title section-heading"><%= t(".open_debates") %></h2>
+    </a>
   </div>
-  <div class="row small-up-1 medium-up-2 large-up-3 card-grid">
-    <% debates.each do |debate| %>
-      <div class="column">
-        <article class="card card--debate">
-          <div class="card__content">
-            <div class="card__header">
-              <%= link_to decidim_debates.debate_path(debate), class: "card__link" do %>
-                <h5 class="card__title"><%= translated_attribute debate.title %></h5>
-              <% end %>
-            </div>
-            <div class="card__datetime">
-              <div class="card__datetime__date">
-                <%= l debate.start_time, format: "%d" %> <span class="card__datetime__month"><%= l debate.start_time, format: "%B" %></span>
-              </div>
-              <div class="card__datetime__time">
-                <%= l debate.start_time, format: "%H:%M" %> - <%= l debate.end_time, format: "%H:%M" %>
-              </div>
-            </div>
-            <p class="card__desc">
-              <%== translated_attribute debate.description %>
-            </p>
-            <% if debate.category.present? %>
-              <ul class="tags tags--debate" >
-                <li><%= link_to translated_attribute(debate.category.name), decidim_debates.debates_path(filter: { category_id: debate.category.id }) %></li>
-              </ul>
+</div>
+<div class="row small-up-1 medium-up-2 large-up-3 card-grid">
+  <% debates.each do |debate| %>
+    <div class="column">
+      <article class="card card--debate">
+        <div class="card__content">
+          <div class="card__header">
+            <%= link_to decidim_debates.debate_path(debate), class: "card__link" do %>
+              <h5 class="card__title"><%= translated_attribute debate.title %></h5>
             <% end %>
           </div>
-          <div class="card__footer">
-            <div class="card__support">
-              <div class="card__support__data"></div>
-              <%= link_to t('.participate'), decidim_debates.debate_path(debate), class: "button small secondary card__button" %>
+          <div class="card__datetime">
+            <div class="card__datetime__date">
+              <%= l debate.start_time, format: "%d" %> <span class="card__datetime__month"><%= l debate.start_time, format: "%B" %></span>
+            </div>
+            <div class="card__datetime__time">
+              <%= l debate.start_time, format: "%H:%M" %> - <%= l debate.end_time, format: "%H:%M" %>
             </div>
           </div>
-        </article>
-      </div>
-    <% end %>
-  </div>
-</main>
+          <p class="card__desc">
+            <%== html_truncate(translated_attribute(debate.description), length: 630, separator: "...") %>
+          </p>
+          <% if debate.category.present? %>
+            <ul class="tags tags--debate" >
+              <li><%= link_to translated_attribute(debate.category.name), decidim_debates.debates_path(filter: { category_id: debate.category.id }) %></li>
+            </ul>
+          <% end %>
+        </div>
+        <div class="card__footer">
+          <div class="card__support">
+            <div class="card__support__data"></div>
+            <%= link_to t('.participate'), decidim_debates.debate_path(debate), class: "button small secondary card__button" %>
+          </div>
+        </div>
+      </article>
+    </div>
+  <% end %>
+</div>

--- a/engines/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/engines/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -3,42 +3,44 @@
 <% content_for :meta_url, debate_url(debate.id) %>
 <% content_for :twitter_handler, current_organization.twitter_handler %>
 
-<div class="wrapper">
-  <div class="row column view-header">
-    <h2 class="heading2">
-      <%== translated_attribute debate.title %>
-    </h2>
-    <% if feature_settings.comments_always_enabled || current_settings.comments_enabled %>
-      <a href="#comments" title="<%= t('.comments') %>">
-        <%= icon "comment-square", aria_label: t('.comments'), role: "img" %> <%= debate.comments.count %>
-      </a>
-    <% end %>
-  </div>
-  <div class="row">
-    <div class="columns section view-side mediumlarge-4 mediumlarge-push-8
-      large-3 large-push-9">
-      <div class="card extra">
-        <div class="card__content">
-          <div class="extra__date">
-            <%= l debate.start_time, format: "%d" %> <span class="extra__month"><%= l debate.start_time, format: "%B" %></span>
-          </div>
-          <div class="extra__time">
-            <%= l debate.start_time, format: "%H:%M" %> - <%= l debate.end_time, format: "%H:%M" %>
-          </div>
+<div class="row column view-header">
+  <h2 class="heading2">
+    <%== translated_attribute debate.title %>
+  </h2>
+  <% if feature_settings.comments_always_enabled || current_settings.comments_enabled %>
+    <a href="#comments" title="<%= t('.comments') %>">
+      <%= icon "comment-square", aria_label: t('.comments'), role: "img" %> <%= debate.comments.count %>
+    </a>
+  <% end %>
+</div>
+<div class="row">
+  <div class="columns section view-side mediumlarge-4 mediumlarge-push-8
+    large-3 large-push-9">
+    <div class="card extra">
+      <div class="card__content">
+        <div class="extra__date">
+          <%= l debate.start_time, format: "%d" %> <span class="extra__month"><%= l debate.start_time, format: "%B" %></span>
+        </div>
+        <div class="extra__time">
+          <%= l debate.start_time, format: "%H:%M" %> - <%= l debate.end_time, format: "%H:%M" %>
         </div>
       </div>
-      <%= render partial: "share", locals: { debate: debate } %>
     </div>
-    <div class="columns mediumlarge-8 mediumlarge-pull-4">
-      <div class="section">
-        <%== translated_attribute debate.description %>
+    <%= render partial: "share", locals: { debate: debate } %>
+  </div>
+  <div class="columns mediumlarge-8 mediumlarge-pull-4">
+    <div class="section">
+      <p><%== translated_attribute debate.description %></p>
+      <% if translated_attribute(debate.instructions).present? %>
         <div class="callout secondary">
-        <%== translated_attribute debate.instructions %>
+          <%== translated_attribute debate.instructions %>
         </div>
+      <% end %>
+      <% if debate.category %>
         <ul class="tags tags--debate">
           <li><%= link_to translated_attribute(debate.category.name), decidim_debates.debates_path(filter: { category_id: debate.category.id }) %></li>
         </ul>
-      </div>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes the debates' layout by removing the unneeded `wrapper`.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/eFO7cWfMUOBUI/giphy.gif)
