### PR TITLE
Fix Dockerfile to work with decidim-debates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,13 @@ ENV SECRET_KEY_BASE $secret_key_base
 
 RUN apt-get update
 
+ENV LANG C.UTF-8
 RUN curl -sL https://deb.nodesource.com/setup_5.x | bash && \
-    apt-get install -y nodejs
+    apt-get install -y nodejs locales
 
 ADD Gemfile /tmp/Gemfile
 ADD Gemfile.lock /tmp/Gemfile.lock
+ADD ./engines/decidim-debates/decidim-debates.gemspec /tmp/engines/decidim-debates/decidim-debates.gemspec
 RUN cd /tmp && bundle install
 
 RUN mkdir -p $APP_HOME


### PR DESCRIPTION
#### :tophat: What? Why?

The Docker image wasn't building because a problem with the locales and bundle install was failing.

#### :pushpin: Related Issues
- Fixes #44
