### PR TITLE
Fix debate explanation text and faq link

### DIFF
--- a/app/views/pages/home/_extended.html.erb
+++ b/app/views/pages/home/_extended.html.erb
@@ -1,0 +1,48 @@
+<section class="extended">
+  <div class="wrapper-home home-section">
+    <div class="row column text-center">
+      <h3 class="heading2"><%= t(".how_to_participate") %></h3>
+    </div>
+    <div class="row small-up-1 medium-up-3 home-bullets">
+      <div class="column">
+        <div class="home-bullet">
+          <div class="home-bullet__icon">
+            <%= icon "meetings" %>
+          </div>
+          <div class="home-bullet__desc">
+            <h4 class="heading6"><%= t(".meetings") %></h4>
+            <p><%= t(".meetings_explanation") %></p>
+          </div>
+        </div>
+      </div>
+      <div class="column">
+        <div class="home-bullet">
+          <div class="home-bullet__icon">
+            <%= icon "debates" %>
+          </div>
+          <div class="home-bullet__desc">
+            <h4 class="heading6"><%= t(".debates") %></h4>
+            <p><%= t(".debates_explanation") %></p>
+          </div>
+        </div>
+      </div>
+      <div class="column">
+        <div class="home-bullet">
+          <div class="home-bullet__icon">
+            <%= icon "proposals" %>
+          </div>
+          <div class="home-bullet__desc">
+            <h4 class="heading6"><%= t(".proposals") %></h4>
+            <p><%= t(".proposals_explanation") %></p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="columns small-centered small-10
+                smallmedium-8 medium-6 large-4">
+        <%= link_to t(".more_info"), page_path("more-information"), class: "button expanded hollow button--sc" %>
+      </div>
+    </div>
+  </div>
+</section>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -31,6 +31,10 @@ ca:
         dni: DNI
         nie: NIE
         passport: Passaport
+  pages:
+    home:
+      extended:
+        debates_explanation: Espais per informar-te i decidir sobre les propostes de cada procés.
   errors:
     messages:
       not_in_district: El codi postal no pertany al districte

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -31,6 +31,10 @@ es:
         dni: DNI
         nie: NIE
         passport: Pasaporte
+  pages:
+    home:
+      extended:
+        debates_explanation: Espacios para informarse y decidir sobre las propuestas de cada proceso.
   errors:
     messages:
       not_in_district: El código postal no pertenece al distrito


### PR DESCRIPTION
#### :tophat: What? Why?

The debates explanation on home page was the same as meetings. I also fixed the broken "faq" page link to "more-information" page.

#### :pushpin: Related Issues
- Fixes #52 
- Fixes #33 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/22923549/3a78e92c-f2a2-11e6-8488-2f3a10c6ecc4.png)

#### :ghost: GIF
![](https://media.giphy.com/media/26tPjh5FzTLPI5wcw/giphy.gif)
