### PR TITLE
Make sure passenger spawns up 5 instances to keep the app hot

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec passenger start -p ${PORT:-3000} --max-pool-size ${WEB_CONCURRENCY:-5}
+web: bundle exec passenger start -p ${PORT:-3000} --max-pool-size ${WEB_CONCURRENCY:-5} --min-instances ${WEB_CONCURRENCY:-5}
 worker: bundle exec sidekiq -e ${RACK_ENV:-development} -C config/sidekiq.yml


### PR DESCRIPTION
#### :tophat: What? Why?
This forces passenger's instance to be fixed to 5 (or configurable with WEB_CONCURRENCY) so resource usage is stable and predictable, and also to keep response times lower (as it doesn't have to spawn new processes).

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/OmmeyBbXMXEGI/giphy.gif)
