### PR TITLE
Fallback to English in production when missing i18n

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [:en]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
#### :tophat: What? Why?
Sometimes we find missing translation texts. While we fix these missing translations, we will fallback to English to at least not show an ugly unescaped HTML dump.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None