### PR TITLE
Add Raven context

### DIFF
--- a/app/controllers/decidim_controller.rb
+++ b/app/controllers/decidim_controller.rb
@@ -3,8 +3,8 @@ class DecidimController < ActionController::Base
   before_action :set_raven_context
 
   def set_raven_context
-    return unless Rails.env.production?
-    Raven.user_context({ id: session[:current_user_id] }.merge(session))
+    return unless Rails.application.secrets.sentry_enabled?
+    Raven.user_context({id: try(:current_user).try(:id)}.merge(session))
     Raven.extra_context(params: params.to_unsafe_h, url: request.url)
   end
 end

--- a/app/controllers/decidim_controller.rb
+++ b/app/controllers/decidim_controller.rb
@@ -1,3 +1,10 @@
 # frozen_string_literal: true
 class DecidimController < ActionController::Base
+  before_action :set_raven_context
+
+  def set_raven_context
+    return unless Rails.env.production?
+    Raven.user_context({ id: session[:current_user_id] }.merge(session))
+    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
+  end
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,6 +11,7 @@
 # if you're sharing your code publicly.
 
 default: &default
+  sentry_enabled: false
   census_url: "<%= ENV['CENSUS_URL'] %>"
   aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
   aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
@@ -45,6 +46,7 @@ test:
 # instead read values from the environment.
 production:
   <<: *default
+  sentry_enabled: true
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   email: "<%= ENV["EMAIL"] %>"
   sendgrid: <%= !ENV["SENDGRID_USERNAME"].blank? %>


### PR DESCRIPTION
#### :tophat: What? Why?
This adds context to our Sentry error reports.

#### :ghost: GIF
![](https://media.giphy.com/media/t7MWRoExDRF72/giphy.gif)