### PR TITLE
Fix logo in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-![decidim-barcelona logo]
-(https://raw.githubusercontent.com/AjuntamentdeBarcelona/decidim.barcelona/master/app/assets/images/decidim-logo.png)
+![decidim-barcelona logo](https://raw.githubusercontent.com/AjuntamentdeBarcelona/decidim.barcelona/master/app/assets/images/decidim-logo.png)
 
 # decidim-barcelona
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fix Markdown syntax so that the logo in the README file is properly shown.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None