### PR TITLE
Install bundler deps only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ branches:
 
 before_script:
   - bundle exec rake db:create db:schema:load
-  - bundle install --jobs=3 --retry=3 --deployment --path="$HOME/.bundle"
 
 env:
   - RAILS_ENV=test


### PR DESCRIPTION
#### :tophat: What? Why?
Execute the `bundle install` command only once, thus shortening TravisCI build time several minutes.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None