### PR TITLE
Show 404 when process slug is not valid

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@ require "sidekiq/web"
 
 Rails.application.routes.draw do
   get "processes/:process_slug", to: redirect { |params, _request|
-    process = Decidim::ParticipatoryProcess.find_by_slug(params[:process_slug])
+    process = Decidim::ParticipatoryProcess.where(slug: params[:process_slug]).first
+    return "/404" unless process
     "/processes/#{process.id}"
   }, constraints: { process_slug: /[^0-9]+/ }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Redirects to `/404` when the slug is not found in the organization processes.

#### :pushpin: Related Issues
- Fixes #96 

#### :clipboard: Subtasks
None