### PR TITLE
Fix comments for debates

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,8 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :letter_opener_web
+
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/engines/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/engines/decidim-debates/app/models/decidim/debates/debate.rb
@@ -7,6 +7,7 @@ module Decidim
     class Debate < Debates::ApplicationRecord
       include Decidim::HasFeature
       include Decidim::HasCategory
+      include Decidim::Resourceable
 
       feature_manifest_name "debates"
 

--- a/engines/decidim-debates/config/i18n-tasks.yml
+++ b/engines/decidim-debates/config/i18n-tasks.yml
@@ -2,4 +2,5 @@ base_locale: ca
 locales: [ca,es]
 ignore_unused:
 - "decidim.features.debates.name"
+- "decidim.features.debates.settings.*"
 - "decidim.debates.*"

--- a/engines/decidim-debates/config/locales/ca.yml
+++ b/engines/decidim-debates/config/locales/ca.yml
@@ -57,3 +57,8 @@ ca:
     features:
       debates:
         name: Debats
+        settings:
+          global:
+            comments_enabled: Comentaris habilitats
+          step:
+            comments_blocked: Comentaris bloquejats

--- a/engines/decidim-debates/config/locales/es.yml
+++ b/engines/decidim-debates/config/locales/es.yml
@@ -57,3 +57,8 @@ es:
     features:
       debates:
         name: Debates
+        settings:
+          global:
+            comments_enabled: Comentarios habilitados
+          step:
+            comments_blocked: Comentarios bloqueados

--- a/engines/decidim-debates/lib/decidim/debates/feature.rb
+++ b/engines/decidim-debates/lib/decidim/debates/feature.rb
@@ -19,6 +19,10 @@ Decidim.register_feature(:debates) do |feature|
     settings.attribute :comments_blocked, type: :boolean, default: false
   end
 
+  feature.register_resource do |resource|
+    resource.model_class_name = "Decidim::Debates::Debate"
+  end
+
   feature.seeds do
     Decidim::ParticipatoryProcess.all.each do |process|
       next unless process.steps.any?

--- a/engines/decidim-debates/spec/factories.rb
+++ b/engines/decidim-debates/spec/factories.rb
@@ -11,4 +11,15 @@ FactoryGirl.define do
     end_time { start_time.advance(hours: 2) }
     feature { build(:feature, manifest_name: "debates") }
   end
+
+  factory :debates_feature, parent: :feature do
+    name { Decidim::Features::Namer.new(participatory_process.organization.available_locales, :debates).i18n_name }
+    manifest_name :debates
+    participatory_process { create(:participatory_process, :with_steps) }
+    settings do
+      {
+        comments_enabled: true
+      }
+    end
+  end
 end

--- a/engines/decidim-debates/spec/features/comments_spec.rb
+++ b/engines/decidim-debates/spec/features/comments_spec.rb
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+# frozen_string_literal: true
+require "spec_helper"
+require "decidim/core/test/factories"
+require "decidim/comments/test/factories"
+
+describe "Comments", type: :feature, perform_enqueued: true do
+  let!(:feature) { create(:debates_feature, organization: organization) }
+  let!(:author) { create(:user, :confirmed, organization: organization) }
+  let!(:commentable) { create(:debate, feature: feature) }
+
+  let(:resource_path) { decidim_debates.debate_path(commentable, feature_id: feature, participatory_process_id: feature.participatory_process) }
+  let!(:organization) { create(:organization) }
+  let!(:user) { create(:user, :confirmed, organization: organization) }
+  let!(:comments) {
+    3.times.map do
+      create(:comment, commentable: commentable)
+    end
+  }
+  let(:authenticated) { false }
+
+  def visit_commentable_path
+    if authenticated
+      login_as user, scope: :user
+    end
+    visit resource_path
+  end
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  it "user should see a list of comments" do
+    visit_commentable_path
+
+    expect(page).to have_selector("#comments")
+    expect(page).to have_selector("article.comment", count: comments.length)
+
+    within "#comments" do
+      comments.each do |comment|
+        expect(page).to have_content comment.author.name
+        expect(page).to have_content comment.body
+      end
+    end
+  end
+
+  it "user should be able to sort the comments" do
+    comment = create(:comment, commentable: commentable, body: "Millor comentari")
+    create(:comment_vote, comment: comment, author: user, weight: 1)
+
+    visit_commentable_path
+
+    within ".order-by" do
+      page.find('.dropdown.menu .is-dropdown-submenu-parent').hover
+    end
+
+    click_link "Més ben valorats"
+
+    within "#comments" do
+      expect(page.find('.comment', match: :first)).to have_content "Millor comentari"
+    end
+  end
+
+  context "when not authenticated" do
+    it "user should not see the form to add comments" do
+      visit_commentable_path
+      expect(page).not_to have_selector(".add-comment form")
+    end
+  end
+
+  context "when authenticated" do
+    let(:authenticated) { true }
+
+    it "user sees the form to add comments" do
+      visit_commentable_path
+
+      expect(page).to have_selector(".add-comment form")
+    end
+
+    context "when user adds a new comment" do
+      before do
+        visit_commentable_path
+
+        expect(page).to have_selector(".add-comment form")
+
+        within ".add-comment form" do
+          fill_in "add-comment-#{commentable.commentable_type}-#{commentable.id}", with: "Nou comentari"
+          click_button "Envia"
+        end
+      end
+
+      it "user visualize the comment" do
+        within "#comments" do
+          expect(page).to have_content user.name
+          expect(page).to have_content "Nou comentari"
+        end
+      end
+
+      it "commentable's author receives notification" do
+        if commentable.respond_to? :author
+          wait_for_email subject: "new comment"
+          login_as commentable.author, scope: :user
+          visit last_email_first_link
+
+          within "#comments" do
+            expect(page).to have_content user.name
+            expect(page).to have_content "Nou comentari"
+          end
+        else
+          expect {
+            wait_for_email subject: "new comment"
+          }.to raise_error StandardError
+        end
+      end
+    end
+
+    context "when the user has verified organizations" do
+      let(:user_group) { create(:user_group, :verified) }
+
+      before do
+        create(:user_group_membership, user: user, user_group: user_group)
+      end
+
+      it "user can add a new comment as a user group" do
+        visit_commentable_path
+
+        expect(page).to have_selector(".add-comment form")
+
+        within ".add-comment form" do
+          fill_in "add-comment-#{commentable.commentable_type}-#{commentable.id}", with: "Nou comentari"
+          select user_group.name, from: "Comentar com a"
+          click_button "Envia"
+        end
+
+        within "#comments" do
+          expect(page).to have_content user_group.name
+          expect(page).to have_content "Nou comentari"
+        end
+      end
+    end
+
+    context "when a user replies a coment" do
+      let!(:comment_author) { create(:user, :confirmed, organization: organization) }
+      let!(:comment) { create(:comment, commentable: commentable, author: comment_author) }
+
+      before do
+        visit_commentable_path
+
+        expect(page).to have_selector(".comment__reply")
+
+        within "#comments #comment_#{comment.id}" do
+          click_button "Respondre"
+          find("textarea").set("Resposta!")
+          click_button "Envia"
+        end
+      end
+
+      it "user visualize the reply" do
+        within "#comments #comment_#{comment.id}" do
+          expect(page).to have_content "Resposta!"
+        end
+      end
+
+      it "comment's author receives notification" do
+        wait_for_email subject: "nova resposta"
+        login_as comment.author, scope: :user
+        visit last_email_first_link
+
+        within "#comments #comment_#{comment.id}" do
+          expect(page).to have_content "Resposta!"
+        end
+      end
+    end
+
+    context "when arguable option is enabled" do
+      before do
+        expect_any_instance_of(commentable.class).to receive(:comments_have_alignment?).and_return(true)
+      end
+
+      it "user can comment in favor" do
+        visit_commentable_path
+
+        expect(page).to have_selector(".add-comment form")
+
+        page.find('.opinion-toggle--ok').click
+
+        within ".add-comment form" do
+          fill_in "add-comment-#{commentable.commentable_type}-#{commentable.id}", with: "I am in favor about this!"
+          click_button "Envia"
+        end
+
+        within "#comments" do
+          expect(page).to have_selector 'span.success.label', text: "A favor"
+        end
+      end
+    end
+
+    context "when votable option is enabled" do
+      before do
+        expect_any_instance_of(commentable.class).to receive(:comments_have_votes?).and_return(true)
+      end
+
+      it "user can upvote a comment" do
+        visit_commentable_path
+
+        within "#comment_#{comments[0].id}" do
+          expect(page).to have_selector('.comment__votes--up', text: /0/)
+          page.find('.comment__votes--up').click
+          expect(page).to have_selector('.comment__votes--up', text: /1/)
+        end
+      end
+
+      it "user can downvote a comment" do
+        visit_commentable_path
+
+        within "#comment_#{comments[0].id}" do
+          expect(page).to have_selector('.comment__votes--down', text: /0/)
+          page.find('.comment__votes--down').click
+          expect(page).to have_selector('.comment__votes--down', text: /1/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
We had reports of failures when trying to send a notification email when a comment was replied on a debate. I found out that `debates` was not using the `Resourceable` module, so the email was failing to generate a needed URL and was not being delivered.

This PR fixes this issue and adds some missing locales in the admin section.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None