### PR TITLE
Fix broken old URLs issue.

### DIFF
--- a/app/services/decidim_legacy_routes.rb
+++ b/app/services/decidim_legacy_routes.rb
@@ -1,0 +1,30 @@
+class DecidimLegacyRoutes
+  def call(params, request)
+
+    feature_translations = {
+      action_plans: [:results, Decidim::Results::Result],
+      meetings: [:meetings, Decidim::Meetings::Meeting],
+      proposals: [:proposals, Decidim::Proposals::Proposal],
+      debates: [:debates, Decidim::Debates::Debate]
+    }
+
+     process = Decidim::ParticipatoryProcess.find_by_slug(params[:process_slug]) || Decidim::ParticipatoryProcess.find(params[:process_slug])
+
+    feature_translation = feature_translations[params[:feature_name].to_sym]
+    feature_manifest_name = feature_translation[0]
+
+    feature = Decidim::Feature.published.find_by(
+      manifest_name: feature_manifest_name,
+      participatory_process: process
+    )
+
+    if params[:resource_id]
+      resource_class = feature_translation[1]
+      resource = resource_class.where("extra->>'slug' = ?", params[:resource_id]).first || resource_class.find(params[:resource_id])
+
+      "/processes/#{process.id}/f/#{feature.id}/#{feature_manifest_name}/#{resource.id}"
+    else
+      "/processes/#{process.id}/f/#{feature.id}"
+    end
+  end
+end

--- a/app/services/decidim_legacy_routes.rb
+++ b/app/services/decidim_legacy_routes.rb
@@ -1,14 +1,12 @@
 class DecidimLegacyRoutes
+  attr_reader :feature_translations
+
+  def initialize(feature_translations)
+    @feature_translations = feature_translations
+  end
+
   def call(params, request)
-
-    feature_translations = {
-      action_plans: [:results, Decidim::Results::Result],
-      meetings: [:meetings, Decidim::Meetings::Meeting],
-      proposals: [:proposals, Decidim::Proposals::Proposal],
-      debates: [:debates, Decidim::Debates::Debate]
-    }
-
-     process = Decidim::ParticipatoryProcess.find_by_slug(params[:process_slug]) || Decidim::ParticipatoryProcess.find(params[:process_slug])
+    process = Decidim::ParticipatoryProcess.find_by_slug(params[:process_slug]) || Decidim::ParticipatoryProcess.find(params[:process_slug])
 
     feature_translation = feature_translations[params[:feature_name].to_sym]
     feature_manifest_name = feature_translation[0]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
     debates: [:debates, Decidim::Debates::Debate]
   }
 
-  # constraints host: "decidim.barcelona" do
+  constraints host: "decidim.barcelona" do
     get "/:process_slug/:step_id/:feature_name/(:resource_id)", to: redirect(DecidimLegacyRoutes.new),
     constraints: { process_id: /[^0-9]+/, step_id: /[0-9]+/, feature_name: Regexp.new(feature_translations.keys.join("|")) }
 
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
       feature_manifest_name = feature.manifest_name
       "/processes/#{process.id}/f/#{feature.id}/#{feature_manifest_name}/#{resource.id}"
     }, constraints: { feature_name: Regexp.new(feature_translations.keys.join("|")) }
-  # end
+  end
 
   authenticate :user, lambda { |u| u.roles.include?("admin") } do
     mount Sidekiq::Web => '/sidekiq'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "sidekiq/web"
-require_relative "../app/services/decidim_legacy_routes"
 
 Rails.application.routes.draw do
   get "processes/:process_slug", to: redirect { |params, _request|
@@ -17,10 +16,10 @@ Rails.application.routes.draw do
   }
 
   constraints host: "decidim.barcelona" do
-    get "/:process_slug/:step_id/:feature_name/(:resource_id)", to: redirect(DecidimLegacyRoutes.new),
+    get "/:process_slug/:step_id/:feature_name/(:resource_id)", to: redirect(DecidimLegacyRoutes.new(feature_translations)),
     constraints: { process_id: /[^0-9]+/, step_id: /[0-9]+/, feature_name: Regexp.new(feature_translations.keys.join("|")) }
 
-    get "/:process_slug/:feature_name/(:resource_id)", to: redirect(DecidimLegacyRoutes.new),
+    get "/:process_slug/:feature_name/(:resource_id)", to: redirect(DecidimLegacyRoutes.new(feature_translations)),
       constraints: { process_id: /[^0-9]+/, feature_name: Regexp.new(feature_translations.keys.join("|")) }
 
     get "/:feature_name/:resource_id", to: redirect { |params, _request|


### PR DESCRIPTION
#### :tophat: What? Why?
We had a couple of old URL which didn't redirect properly on production. I found out that we were missing a `process` route without `step_id`, so this PR adds a `DecidimLegacyUrl` class that should fix most of the related cases. 

#### :pushpin: Related Issues
- Fixes #111
