### PR TITLE
Update the routes constraint to fix old broken urls.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
     debates: [:debates, Decidim::Debates::Debate]
   }
 
-  constraints host: "decidim.barcelona" do
+  constraints host: /(www\.)?decidim\.barcelona/ do
     get "/:process_slug/:step_id/:feature_name/(:resource_id)", to: redirect(DecidimLegacyRoutes.new(feature_translations)),
     constraints: { process_id: /[^0-9]+/, step_id: /[0-9]+/, feature_name: Regexp.new(feature_translations.keys.join("|")) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Looks like the constraint we were using was obsolete since the host it's `www.decidim.barcelona`, this PR updates the constraint with a RegExp to match the host properly.

#### :pushpin: Related Issues
- Fixes #111 
