### PR TITLE
Don't enforce ssl on certain hosts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :production do
   gem "newrelic_rpm"
   gem "dalli"
   gem "sentry-raven"
+  gem 'rack-ssl-enforcer'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -447,6 +447,7 @@ GEM
     rack-cors (0.4.1)
     rack-protection (1.5.3)
       rack
+    rack-ssl-enforcer (0.2.9)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.2)
@@ -636,6 +637,7 @@ DEPENDENCIES
   newrelic_rpm
   passenger
   progressbar
+  rack-ssl-enforcer
   rails_12factor
   rainbow (~> 2.2.0)
   rspec-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,8 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
+  config.middleware.use Rack::SslEnforcer, except_hosts: ENV["EXCEPT_SSL_HOSTS"].split(",")
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
#### :tophat: What? Why?
This allows skipping certain hosts when forcing SSL with the end goal of proxying the sites from the outside.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/a9imQoghMq5IQ/giphy.gif)
