### PR TITLE
Fix local jump on routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,7 @@ require "sidekiq/web"
 Rails.application.routes.draw do
   get "processes/:process_slug", to: redirect { |params, _request|
     process = Decidim::ParticipatoryProcess.where(slug: params[:process_slug]).first
-    return "/404" unless process
-    "/processes/#{process.id}"
+    process ? "/processes/#{process.id}" : "/404"
   }, constraints: { process_slug: /[^0-9]+/ }
 
   feature_translations = {


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes a `LocalJump` exception in routes, since we're using blocks and `return` is invalid.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/l41lVsYDBC0UVQJCE/giphy.gif)
