### PR TITLE
Conditionally show accountability depending on the organization

### DIFF
--- a/config/initializers/main_navigation.rb
+++ b/config/initializers/main_navigation.rb
@@ -1,6 +1,0 @@
-Decidim.menu :menu do |menu|
-  menu.item I18n.t("menu.accountability_static"),
-            DecidimBarcelona::Application.routes.url_helpers.accountability_static_path,
-            position: 4,
-            active: :inclusive
-end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -35,8 +35,6 @@ ca:
     resource_links:
       included_proposals:
         project_proposals: "Propostes incloses en aquest projecte:"
-  menu:
-    accountability_static: Rendició de comptes
   pages:
     home:
       extended:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,5 +7,3 @@ en:
         dni: DNI
         nie: NIE
         passport: Passport
-  menu:
-    accountability_static: Accountability

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -35,8 +35,6 @@ es:
     resource_links:
       included_proposals:
         project_proposals: "Propuestas incluidas en éste proyecto:"
-  menu:
-    accountability_static: Rendición de cuentas
   pages:
     home:
       extended:

--- a/decidim-dataviz/config/locales/ca.yml
+++ b/decidim-dataviz/config/locales/ca.yml
@@ -2,6 +2,8 @@
 ca:
   decidim:
     dataviz:
+      menu:
+        accountability_static: Rendició de comptes
       dataviz:
         open_data:
           download-action_plans: Actuacions (.csv)

--- a/decidim-dataviz/config/locales/es.yml
+++ b/decidim-dataviz/config/locales/es.yml
@@ -2,6 +2,8 @@
 es:
   decidim:
     dataviz:
+      menu:
+        accountability_static: Rendición de cuentas
       dataviz:
         open_data:
           download-action_plans: Actuaciones (.csv)

--- a/decidim-dataviz/lib/decidim/dataviz/engine.rb
+++ b/decidim-dataviz/lib/decidim/dataviz/engine.rb
@@ -18,6 +18,17 @@ module Decidim
       initializer "decidim_dataviz.public" do |app|
         app.middleware.insert_before(::ActionDispatch::Static, ::ActionDispatch::Static, "#{root}/public")
       end
+
+      initializer "decidim_dataviz.menu" do |_app|
+        Decidim.menu :menu do |menu|
+          if current_organization.host == "www.decidim.barcelona"
+            menu.item I18n.t("decidim.dataviz.menu.accountability_static"),
+                      DecidimBarcelona::Application.routes.url_helpers.accountability_static_path,
+                      position: 4,
+                      active: :inclusive
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This refactors the accountability menu and conditionally shows it depending on the organization's host.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/l2Je57ilZJPzNkeXK/giphy.gif)
