### PR TITLE
Fix legacy routes redirector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
 
 before_script:
   - bundle exec rake db:create db:schema:load
-  - bundle exec rake decidim:generate_test_app  
+  - bundle exec rake decidim:generate_test_app
 
 env:
   - RAILS_ENV=test
@@ -25,6 +25,7 @@ cache:
     - $BUNDLE_PATH
     - vendor/bundle
 script:
+  - bundle exec rake
   - cd decidim-debates && bundle exec rake
 
 rvm:

--- a/app/services/decidim_legacy_routes.rb
+++ b/app/services/decidim_legacy_routes.rb
@@ -13,7 +13,7 @@ class DecidimLegacyRoutes
 
     feature = Decidim::Feature.published.find_by(
       manifest_name: feature_manifest_name,
-      participatory_process: process
+      participatory_space: process
     )
 
     if params[:resource_id]

--- a/spec/routing/redirections_spec.rb
+++ b/spec/routing/redirections_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 require "decidim/dev/test/spec_helper"
 require "decidim/core/test/factories"
+require "decidim/participatory_processes/test/factories"
 require "decidim/proposals/test/factories"
 
 describe "routing redirections", type: :request do
@@ -8,7 +9,7 @@ describe "routing redirections", type: :request do
 
   describe "proposals" do
     let!(:participatory_process) { create(:participatory_process, organization: organization, slug: "test-process") }
-    let!(:feature) { create(:proposal_feature, participatory_process: participatory_process) }
+    let!(:feature) { create(:proposal_feature, participatory_space: participatory_process) }
     let!(:proposal) { create(:proposal, feature: feature, extra: { slug: "test-proposal" }) }
 
     context "with the right host" do
@@ -18,6 +19,11 @@ describe "routing redirections", type: :request do
 
       it "redirects top-level proposals" do
         expect(get("/proposals/test-proposal"))
+          .to redirect_to("/processes/#{participatory_process.id}/f/#{feature.id}/proposals/#{proposal.id}")
+      end
+
+      it "redirects proposals inside the old structure without step ID" do
+        expect(get("/test-process/proposals/test-proposal"))
           .to redirect_to("/processes/#{participatory_process.id}/f/#{feature.id}/proposals/#{proposal.id}")
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
We had some errors when redirecting legacy routes to the new system. I found that we had tests, but somehow they were not running on CI so we didn't notice this was failing 👍 

I've added the app tests to the CI, fixed the redirector and added a new test case to solve the issue on Sentry.

#### :pushpin: Related Issues
None
