### PR TITLE
Use virtus multiparams to coerce dates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem "decidim-debates", path: "decidim-debates"
 gem "decidim-dataviz", path: "decidim-dataviz"
 gem "decidim-accountability", ">= 0.1.2"
 
+gem "virtus-multiparams"
+
 gem 'uglifier', '>= 1.3.0'
 gem 'lograge'
 gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -610,6 +610,8 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    virtus-multiparams (0.1.1)
+      virtus (~> 1.0)
     warden (1.2.7)
       rack (>= 1.0)
     webmock (3.1.0)
@@ -655,9 +657,10 @@ DEPENDENCIES
   spring-watcher-listen
   tzinfo-data
   uglifier (>= 1.3.0)
+  virtus-multiparams
 
 RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.4
+   1.16.0.pre.3

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -6,6 +6,7 @@ require "digest/md5"
 # to verify the citizen's residence.
 class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   include ActionView::Helpers::SanitizeHelper
+  include Virtus::Multiparams
 
   attribute :document_number, String
   attribute :document_type, Symbol
@@ -22,24 +23,6 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   validate :document_type_valid
   validate :over_16
   validate :valid_postal_code
-
-  def self.from_params(params, additional_params = {})
-    instance = super(params, additional_params)
-
-    params_hash = hash_from(params)
-
-    if params_hash["date_of_birth(1i)"]
-      date = Date.civil(
-        params["date_of_birth(1i)"].to_i,
-        params["date_of_birth(2i)"].to_i,
-        params["date_of_birth(3i)"].to_i
-      )
-
-      instance.date_of_birth = date
-    end
-
-    instance
-  end
 
   # If you need to store any of the defined attributes in the authorization you
   # can do it here.


### PR DESCRIPTION
#### :tophat: What? Why?
Use virtus multiparams to coerce dates instead of relying to custom coercing. Fixes impersonation.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*
