### PR TITLE
Fix scopes in census authorization form

### DIFF
--- a/app/views/census_authorization/_form.html.erb
+++ b/app/views/census_authorization/_form.html.erb
@@ -15,7 +15,7 @@
 </div>
 
 <div class="field">
-  <%= form.collection_select :scope_id, current_organization.scopes, :id, :name, prompt: t(".scope_prompt") %>
+  <%= form.collection_select :scope_id, current_organization.scopes, :id, ->(scope){ translated_attribute(scope.name) }, prompt: t(".scope_prompt") %>
 </div>
 
 <%= form.hidden_field :handler_name %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+require "decidim/core/test/factories"

--- a/spec/features/census_authorization_spec.rb
+++ b/spec/features/census_authorization_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Authorizations", type: :feature, perform_enqueued: true do
+  let(:organization) { create :organization, available_authorizations: authorizations }
+  let!(:scope) { create :scope, organization: organization }
+  let(:authorizations) { ["CensusAuthorizationHandler"] }
+  let(:response) do
+    Nokogiri::XML("<codiRetorn>01</codiRetorn>").remove_namespaces!
+  end
+
+  # Selects a birth date that will not cause errors in the form: January 12, 1979.
+  def fill_in_authorization_form
+    select "DNI", from: "authorization_handler_document_type"
+    fill_in "authorization_handler_document_number", with: "12345678A"
+    select "12", from: "authorization_handler_date_of_birth_3i"
+    select "January", from: "authorization_handler_date_of_birth_2i"
+    select "1979", from: "authorization_handler_date_of_birth_1i"
+    fill_in "authorization_handler_postal_code", with: "08007"
+    select translated(scope.name), from: "authorization_handler_scope_id"
+  end
+
+  before do
+    Decidim.authorization_handlers = ["CensusAuthorizationHandler"]
+    allow_any_instance_of(CensusAuthorizationHandler).to receive(:response).and_return(response)
+    switch_to_host(organization.host)
+  end
+
+  context "a new user" do
+    let(:user) { create(:user, :confirmed, organization: organization) }
+
+    context "when one authorization has been configured" do
+      before do
+        visit decidim.root_path
+        find(".sign-in-link").click
+
+        within "form.new_user" do
+          fill_in :user_email, with: user.email
+          fill_in :user_password, with: "password1234"
+          find("*[type=submit]").click
+        end
+      end
+
+      it "redirects the user to the authorization form after the first sign in" do
+        allow(PostalCodeDistricts).to receive(:valid?).and_return(true)
+
+        fill_in_authorization_form
+        click_button "Send"
+        expect(page).to have_content("successfully")
+      end
+
+      it "allows the user to skip it" do
+        find(".skip a").click
+        expect(page).to have_content("User settings")
+      end
+    end
+  end
+
+  context "user account" do
+    let(:user) { create(:user, :confirmed) }
+
+    before do
+      login_as user, scope: :user
+      visit decidim.root_path
+
+      allow(PostalCodeDistricts).to receive(:valid?).and_return(true)
+    end
+
+    it "allows the user to authorize against available authorizations" do
+      visit decidim.new_authorization_path(handler: "census_authorization_handler")
+
+      fill_in_authorization_form
+      click_button "Send"
+
+      expect(page).to have_content("successfully")
+
+      visit decidim.authorizations_path
+
+      within ".authorizations-list" do
+        expect(page).to have_content("El padró")
+        expect(page).not_to have_link("El padró")
+      end
+    end
+
+    context "when the user has already been authorised" do
+      let!(:authorization) do
+        create(:authorization,
+               name: CensusAuthorizationHandler.handler_name,
+               user: user)
+      end
+
+      it "shows the authorization at their account" do
+        visit decidim.authorizations_path
+
+        within ".authorizations-list" do
+          expect(page).to have_content("El padró")
+          expect(page).not_to have_link("El padró")
+          expect(page).to have_content(I18n.localize(authorization.created_at, format: :long))
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,13 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+
+require "decidim/dev"
+
+Decidim::Dev.dummy_app_path = File.expand_path(File.join(__dir__, ".."))
+
+require "decidim/dev/test/base_spec_helper"
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes the census form to show the proper scopes names in the `select` attribute, instead of showing the IDs

#### :pushpin: Related Issues
- Fixes #162
