### PR TITLE
Ignore city scope in Census form.

### DIFF
--- a/app/views/census_authorization/_form.html.erb
+++ b/app/views/census_authorization/_form.html.erb
@@ -15,7 +15,7 @@
 </div>
 
 <div class="field">
-  <%= form.collection_select :scope_id, current_organization.scopes, :id, ->(scope){ translated_attribute(scope.name) }, prompt: t(".scope_prompt") %>
+  <%= form.collection_select :scope_id, current_organization.scopes.select {|scope| scope.name["ca"] != "Ciutat" }, :id, ->(scope){ translated_attribute(scope.name) }, prompt: t(".scope_prompt") %>
 </div>
 
 <%= form.hidden_field :handler_name %>


### PR DESCRIPTION
#### :tophat: What? Why?

Don't display the "Ciutat" district at the census verification form.

#### :pushpin: Related Issues
- Fixes #170