### PR TITLE
Assemblies: change menu and others strings (#205)

### DIFF
--- a/config/locales/assemblies.ca.yml
+++ b/config/locales/assemblies.ca.yml
@@ -1,0 +1,84 @@
+ca:
+  decidim:
+    admin:
+      assemblies:
+        create:
+          error: S'ha produït un error en crear un nou òrgan.
+          success: Òrgan creada correctament.
+        destroy:
+          success: L'òrgan s'ha eliminat amb èxit.
+        new:
+          title: Nou òrgan
+        update:
+          error: S'ha produït un error en actualitzar aquesta assemblea.
+          success: L'assemblea s'ha actualitzat correctament.
+      assemblies_copies:
+        create:
+          error: S'ha produït un error en duplicar aquesta assemblea.
+          success: L'assemblea s'ha duplicat correctament.
+      assembly_copies:
+        new:
+          title: Òrgan duplicat
+      assembly_publications:
+        create:
+          error: S'ha produït un error en publicar aquest òrgan.
+          success: Òrgan publicat amb èxit.
+        destroy:
+          error: S'ha produït un error en despublicar aquest òrgan.
+          success: Òrgan despublicat amb èxit.
+      assembly_user_roles:
+        create:
+          error: S'ha produït un error en afegir un usuari per a aquest òrgan.
+          success: L'usuari s'ha creat correctament per a aquest òrgan.
+        destroy:
+          success: S'ha destruït l'usuari amb èxit per a aquest òrgan.
+        edit:
+          title: Actualitza l'usuari de l'òrgan.
+        index:
+          assembly_admins_title: Usuaris de l'òrgan
+        new:
+          title: Nou usuari de l'òrgan.
+        update:
+          error: S'ha produït un error en l'actualització d'un usuari per a aquest òrgan.
+          success: L'usuari s'ha actualitzat correctament per a aquest òrgan.
+      menu:
+        assemblies: Òrgans
+        assemblies_submenu:
+          assembly_admins: Usuaris de l'òrgan
+      models:
+        assembly:
+          name: Òrgan
+        assembly_user_role:
+          name: Usuari de l'òrgan
+      titles:
+        assemblies: Òrgans
+    assemblies:
+      admin:
+        assemblies:
+          form:
+            slug_help: 'Els noms curts d''URL s''utilitzen per generar les URL que apunten a aquest òrgan. Només accepta lletres, números i guions, i ha de començar amb una lletra. Exemple: %{url}'
+        assembly_copies:
+          form:
+            slug_help: 'Els noms curts d''URL s''utilitzen per generar els URL que apunten a aquest òrgan. Només accepta lletres, números i guions, i ha de començar amb una lletra. Exemple: %{url}'
+      index:
+        title: Òrgans
+      pages:
+        home:
+          highlighted_assemblies:
+            active_assemblies: Òrgans actius
+            see_all_assemblies: Veure tots els òrgans
+      statistics:
+        assemblies_count: Òrgans
+    menu:
+      assemblies: Òrgans
+  layouts:
+    decidim:
+      assemblies:
+        index:
+          promoted_assemblies: Òrgans destacats
+        order_by_assemblies:
+          assemblies:
+            one: "%{count} òrgan"
+            other: "%{count} òrgans"
+      assembly_header:
+        assembly_menu_item: L'òrgan

--- a/config/locales/assemblies.ca.yml
+++ b/config/locales/assemblies.ca.yml
@@ -4,21 +4,21 @@ ca:
       assemblies:
         create:
           error: S'ha produït un error en crear un nou òrgan.
-          success: Òrgan creada correctament.
+          success: Òrgan creat correctament.
         destroy:
-          success: L'òrgan s'ha eliminat amb èxit.
+          success: Òrgan eliminat correctament.
         new:
-          title: Nou òrgan
+          title: Nou òrgan.
         update:
-          error: S'ha produït un error en actualitzar aquesta assemblea.
-          success: L'assemblea s'ha actualitzat correctament.
+          error: S'ha produït un error en actualitzar aquest òrgan.
+          success: L'òrgan s'ha actualitzat correctament.
       assemblies_copies:
         create:
-          error: S'ha produït un error en duplicar aquesta assemblea.
+          error: S'ha produït un error en duplicar aquest òrgan.
           success: L'assemblea s'ha duplicat correctament.
       assembly_copies:
         new:
-          title: Òrgan duplicat
+          title: Duplicar òrgan.
       assembly_publications:
         create:
           error: S'ha produït un error en publicar aquest òrgan.
@@ -28,14 +28,14 @@ ca:
           success: Òrgan despublicat amb èxit.
       assembly_user_roles:
         create:
-          error: S'ha produït un error en afegir un usuari per a aquest òrgan.
-          success: L'usuari s'ha creat correctament per a aquest òrgan.
+          error: S'ha produït un error en afegir un usuari en aquest òrgan.
+          success: L'usuari s'ha creat correctament en aquest òrgan.
         destroy:
-          success: S'ha destruït l'usuari amb èxit per a aquest òrgan.
+          success: Usuari en aquest òrgan eliminat amb èxit.
         edit:
-          title: Actualitza l'usuari de l'òrgan.
+          title: Edita l'usuari de l'òrgan.
         index:
-          assembly_admins_title: Usuaris de l'òrgan
+          assembly_admins_title: Usuaris de l'òrgan.
         new:
           title: Nou usuari de l'òrgan.
         update:
@@ -44,12 +44,12 @@ ca:
       menu:
         assemblies: Òrgans
         assemblies_submenu:
-          assembly_admins: Usuaris de l'òrgan
+          assembly_admins: Usuaris de l'òrgan.
       models:
         assembly:
           name: Òrgan
         assembly_user_role:
-          name: Usuari de l'òrgan
+          name: Rols d'usuari de l'òrgan
       titles:
         assemblies: Òrgans
     assemblies:
@@ -81,4 +81,4 @@ ca:
             one: "%{count} òrgan"
             other: "%{count} òrgans"
       assembly_header:
-        assembly_menu_item: L'òrgan
+        assembly_menu_item: Òrgan

--- a/config/locales/assemblies.es.yml
+++ b/config/locales/assemblies.es.yml
@@ -6,9 +6,9 @@ es:
           error: Se produjo un error al crear un nuevo órgano.
           success: Órgano creado correctamente.
         destroy:
-          success: Órgano destruido correctamente.
+          success: Órgano eliminado correctamente.
         new:
-          title: Nuevo órgano
+          title: Nuevo órgano.
         update:
           error: Se ha producido un error al actualizar este órgano.
           success: El órgano se ha actualizado correctamente.
@@ -18,24 +18,24 @@ es:
           success: Órgano duplicado correctamente.
       assembly_copies:
         new:
-          title: Duplicar órgano
+          title: Duplicar órgano.
       assembly_publications:
         create:
           error: Se produjo un error al publicar este órgano.
           success: Órgano publicado con éxito.
         destroy:
           error: Se produjo un error al despublicar este órgano.
-          success: Órgano despublicado con éxito.
+          success: Órgano eliminado con éxito.
       assembly_user_roles:
         create:
-          error: Se ha producido un error al agregar un usuario para este órgano.
+          error: Se ha producido un error al crear un usuario en este órgano.
           success: Usuario creado con éxito para este órgano.
         destroy:
-          success: Usuario destruido con éxito para este órgano.
+          success: Usuario en este órgano eliminado con éxito.
         edit:
-          title: Actualizar el usuario del órgano.
+          title: Edita el usuario del órgano.
         index:
-          assembly_admins_title: Usuarios del Órgano
+          assembly_admins_title: Usuarios del órgano.
         new:
           title: Nuevo usuario del órgano.
         update:
@@ -49,7 +49,7 @@ es:
         assembly:
           name: Órgano
         assembly_user_role:
-          name: Usuario del órgano
+          name: Roles de usuario del órgano.
       titles:
         assemblies: Órganos
     assemblies:
@@ -81,4 +81,4 @@ es:
             one: "%{count} órgano"
             other: "%{count} órganos"
       assembly_header:
-        assembly_menu_item: El órgano
+        assembly_menu_item: Órgano

--- a/config/locales/assemblies.es.yml
+++ b/config/locales/assemblies.es.yml
@@ -1,0 +1,84 @@
+es:
+  decidim:
+    admin:
+      assemblies:
+        create:
+          error: Se produjo un error al crear un nuevo órgano.
+          success: Órgano creado correctamente.
+        destroy:
+          success: Órgano destruido correctamente.
+        new:
+          title: Nuevo órgano
+        update:
+          error: Se ha producido un error al actualizar este órgano.
+          success: El órgano se ha actualizado correctamente.
+      assemblies_copies:
+        create:
+          error: Se produjo un error al duplicar este órgano.
+          success: Órgano duplicado correctamente.
+      assembly_copies:
+        new:
+          title: Duplicar órgano
+      assembly_publications:
+        create:
+          error: Se produjo un error al publicar este órgano.
+          success: Órgano publicado con éxito.
+        destroy:
+          error: Se produjo un error al despublicar este órgano.
+          success: Órgano despublicado con éxito.
+      assembly_user_roles:
+        create:
+          error: Se ha producido un error al agregar un usuario para este órgano.
+          success: Usuario creado con éxito para este órgano.
+        destroy:
+          success: Usuario destruido con éxito para este órgano.
+        edit:
+          title: Actualizar el usuario del órgano.
+        index:
+          assembly_admins_title: Usuarios del Órgano
+        new:
+          title: Nuevo usuario del órgano.
+        update:
+          error: Ha habido un error al actualizar un usuario para este órgano.
+          success: Usuario actualizado con éxito para este órgano.
+      menu:
+        assemblies: Órganos
+        assemblies_submenu:
+          assembly_admins: Usuarios de los órganos
+      models:
+        assembly:
+          name: Órgano
+        assembly_user_role:
+          name: Usuario del órgano
+      titles:
+        assemblies: Órganos
+    assemblies:
+      admin:
+        assemblies:
+          form:
+            slug_help: 'Los textos cortos de URL se utilizan para generar las URL que apuntan a este órgano. Sólo acepta letras, números y guiones, y debe comenzar con una letra. Ejemplo: %{url}'
+        assembly_copies:
+          form:
+            slug_help: 'Los textos cortos de URL se utilizan para generar las URL que apuntan a este órgano. Sólo acepta letras, números y guiones, y debe comenzar con una letra. Ejemplo: %{url}'
+      index:
+        title: Órganos
+      pages:
+        home:
+          highlighted_assemblies:
+            active_assemblies: Órganos activos
+            see_all_assemblies: Ver todos los órganos
+      statistics:
+        assemblies_count: Órganos
+    menu:
+      assemblies: Órganos
+  layouts:
+    decidim:
+      assemblies:
+        index:
+          promoted_assemblies: Órganos destacados
+        order_by_assemblies:
+          assemblies:
+            one: "%{count} órgano"
+            other: "%{count} órganos"
+      assembly_header:
+        assembly_menu_item: El órgano


### PR DESCRIPTION
#### :tophat: What? Why?

This changes the "assemblies" to "órganos/òrgans", to reflect the naming of this kind of space's here on Barcelona.

#### :pushpin: Related Issues
- Fixes #205 

### :camera: Screenshots (optional)
![imagen](https://user-images.githubusercontent.com/717367/36728292-8bfad90c-1bc0-11e8-8f6d-820804d97de9.png)

#### :ghost: GIF
![](https://media1.giphy.com/media/26xBCASzq1xNJGZJ6/giphy.gif)
