### PR TITLE
Add CSP headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'faker'
 gem "deface"
 gem "progressbar"
 gem "puma"
+gem "secure_headers"
 
 group :development, :test do
   gem 'byebug', platform: :mri

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'faker'
 gem "deface"
 gem "progressbar"
 gem "puma"
-gem "secure_headers"
 
 group :development, :test do
   gem 'byebug', platform: :mri
@@ -43,6 +42,7 @@ group :production do
   gem 'rack-ssl-enforcer'
   gem 'rails_autoscale_agent'
   gem "rack_password"
+  gem "secure_headers"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -586,6 +586,7 @@ GEM
       sprockets-rails
       tilt
     searchlight (4.1.0)
+    secure_headers (6.0.0)
     selenium-webdriver (3.11.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
@@ -690,6 +691,7 @@ DEPENDENCIES
   rails_autoscale_agent
   rspec-rails
   rubocop
+  secure_headers
   sentry-raven
   sidekiq
   spring

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,0 +1,44 @@
+if Rails.env.production?
+  SecureHeaders::Configuration.default do |config|
+    config.cookies = {
+      secure: true, # mark all cookies as "Secure"
+      httponly: true, # mark all cookies as "HttpOnly"
+      samesite: {
+        lax: true # mark all cookies as SameSite=lax
+      }
+    }
+
+    # Add "; preload" and submit the site to hstspreload.org for best protection.
+    config.hsts = "max-age=#{1.week.to_i}"
+    config.x_frame_options = "DENY"
+    config.x_content_type_options = "nosniff"
+    config.x_xss_protection = "1; mode=block"
+    config.x_download_options = "noopen"
+    config.x_permitted_cross_domain_policies = "none"
+    config.referrer_policy = %w(origin-when-cross-origin strict-origin-when-cross-origin)
+    config.csp = {
+      # "meta" values. these will shape the header, but the values are not included in the header.
+      preserve_schemes: true, # default: false. Schemes are removed from host sources to save bytes and discourage mixed content.
+
+      # directive values: these values will directly translate into source directives
+      default_src: %w('none'),
+      base_uri: %w('self'),
+      block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
+      child_src: %w(www.youtube.com 'self'), # if child-src isn't supported, the value for frame-src will be set.
+      connect_src: %w(wss:),
+      font_src: %w('self' data:),
+      form_action: %w('self'),
+      frame_ancestors: %w('none'),
+      img_src: %w(*.maps.api.here.com decidim-barcelona-new.s3.amazonaws.com ajuntament.barcelona.cat data:),
+      manifest_src: %w('self'),
+      media_src: %w('self'),
+      object_src: %w('self'),
+      sandbox: true, # true and [] will set a maximally restrictive setting
+      plugin_types: %w(application/x-shockwave-flash),
+      script_src: %w(ajuntament.barcelona.cat 'self'),
+      style_src: %w('unsafe-inline'),
+      worker_src: %w('self'),
+      upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
+    }
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Adds CSP headers to prevent XSS attacks. Documentation taken from: https://blog.sqreen.io/integrating-content-security-policy-into-your-rails-applications-4f883eed8f45/

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/issues/117

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*
