### PR TITLE
Redirect missing page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,8 @@ Rails.application.routes.draw do
     post :import_results, to: "decidim/accountability/admin/import_results#create"
   end
 
+  get "/pages/faq", to: redirect("/pages/more-information")
+
   mount Decidim::Core::Engine => "/"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
#### :tophat: What? Why?
For some reason, a default page is missing. This PR adds a redirect to overcome this problem.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None