### PR TITLE
Add SMS gateway service

### DIFF
--- a/app/services/sms_gateway.rb
+++ b/app/services/sms_gateway.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# This class sends an SMS to a user so they can verify their
+# phone number.
+class SmsGateway
+  attr_reader :mobile_phone_number, :code
+
+  def initialize(mobile_phone_number, code)
+    @mobile_phone_number = mobile_phone_number
+    @code = code
+  end
+
+  def deliver_code
+    raise "Pending to implement"
+  end
+end

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -19,6 +19,8 @@ Decidim.configure do |config|
       here_app_code: Rails.application.secrets.geocoder[:here_app_code]
     }
   end
+
+  config.sms_gateway_service = "SmsGateway"
 end
 
 Decidim::Verifications.register_workflow(:census_authorization_handler) do |auth|


### PR DESCRIPTION
#### :tophat: What? Why?

This adds a SMS gateway service so users can verify their phone number. 

We still need the configuration details from the city council in order to implement this.

#### :pushpin: Related Issues
- Depends on https://github.com/decidim/decidim/pull/4429