### PR TITLE
Fix census form scope list and locales

### DIFF
--- a/app/views/census_authorization/_form.html.erb
+++ b/app/views/census_authorization/_form.html.erb
@@ -15,7 +15,7 @@
 </div>
 
 <div class="field">
-  <%= form.collection_select :scope_id, current_organization.scopes.select {|scope| scope.name["ca"] != "Ciutat" }, :id, ->(scope){ translated_attribute(scope.name) }, prompt: t(".scope_prompt") %>
+  <%= form.collection_select :scope_id, current_organization.scopes.where(parent_id: nil).select {|scope| scope.name["ca"] != "Ciutat" }, :id, ->(scope){ translated_attribute(scope.name) }, prompt: t(".scope_prompt") %>
 </div>
 
 <%= form.hidden_field :handler_name %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -61,6 +61,11 @@ ca:
     resource_links:
       included_proposals:
         project_proposals: 'Propostes incloses en aquest projecte:'
+    verifications:
+      authorizations:
+        first_login:
+          actions:
+            census_authorization_handler: Verifica't amb el padró
   errors:
     messages:
       not_in_district: El codi postal no pertany al districte

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -7,7 +7,7 @@ es:
         document_number: Número de documento
         document_type: Tipo de documento
         postal_code: Código postal
-        scope: Distrito
+        scope_id: Distrito
   census_authorization:
     form:
       date_select:
@@ -61,6 +61,11 @@ es:
     resource_links:
       included_proposals:
         project_proposals: 'Propuestas incluidas en éste proyecto:'
+    verifications:
+      authorizations:
+        first_login:
+          actions:
+            census_authorization_handler: Verifícate con el padrón
   errors:
     messages:
       not_in_district: El código postal no pertenece al distrito


### PR DESCRIPTION
#### :tophat: What? Why?

The census form should only show top level scopes, otherwise we're also showing neighbourhoods.
