### PR TITLE
Remove rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ end
 group :production do
   gem "passenger"
   gem "sidekiq"
-  gem "rails_12factor"
   gem "fog-aws"
   gem "newrelic_rpm"
   gem "dalli"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -586,13 +586,8 @@ GEM
     rails-i18n (5.1.2)
       i18n (>= 0.7, < 2)
       railties (>= 5.0, < 6)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
     rails_autoscale_agent (0.3.1)
       activesupport (>= 3.2)
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.2.2)
       actionpack (= 5.2.2)
       activesupport (= 5.2.2)
@@ -784,7 +779,6 @@ DEPENDENCIES
   puma
   rack-ssl-enforcer
   rack_password
-  rails_12factor
   rails_autoscale_agent
   rspec-rails
   rubocop


### PR DESCRIPTION
#### :tophat: What? Why?

This PR just removes the rails_12factor gem which is [not necessary anymore since Rails 5](https://github.com/heroku/rails_12factor#new-rails-5-apps).

It has already been [removed](https://github.com/decidim/decidim/issues/1095) from the decidim generators in 2017.

#### :pushpin: Related Issues
- Related to [decidim/#1095](https://github.com/decidim/decidim/issues/1095)