### PR TITLE
Update decidim commit version to incorporate OAuth fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/decidim/decidim
-  revision: a867cedde4ebb81f8923e03793a636ed4c042c30
+  revision: 45a62d47fcc007fbcbe1a3e73b2b7bed51fdd04c
   branch: 0.15-stable
   specs:
     decidim (0.15.2)


### PR DESCRIPTION
#### :tophat: What? Why?

Currently, it is not possible to use OAuth authentication using decidim.barcelona as provider due the bug [#4133](https://github.com/decidim/decidim/issues/4133) which causes to respond with a 500 error if the user has an avatar image in his profile.

Currently this affects logins from https://meta.decidim.org and other comming platforms using decidim.barcelona as OAuth provider.

This incorporates the fix [#4917](https://github.com/decidim/decidim/pull/4917) as a [backport](https://github.com/decidim/decidim/commit/45a62d47fcc007fbcbe1a3e73b2b7bed51fdd04c). 

