### PR TITLE
Make sure we always calculate the authorization unique_id the same way

### DIFF
--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -45,7 +45,7 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
 
   def unique_id
     Digest::MD5.hexdigest(
-      "#{document_number}-#{Rails.application.secrets.secret_key_base}"
+      "#{document_number&.upcase}-#{Rails.application.secrets.secret_key_base}"
     )
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

If the document number param had the letter in lowercase or upcase the hash would be different.
