### PR TITLE
[CONFIG] Set default_signature_time_period_length = 60.

### DIFF
--- a/config/initializers/initiatives.rb
+++ b/config/initializers/initiatives.rb
@@ -3,4 +3,5 @@
 Decidim::Initiatives.configure do |config|
   config.face_to_face_voting_allowed = true
   config.online_voting_allowed = true
+  config.default_signature_time_period_length = 60
 end


### PR DESCRIPTION
#### :tophat: What? Why?
By default initiatives will be open during 60 days.

#### :pushpin: Related Issues
- Related to DECIDIM-31

#### :clipboard: Subtasks
- [x] Subtask 1
- [ ] Subtask 2

### :camera: Screenshots (optional)
![Description](URL)

#### :ghost: GIF
![]()
