### PR TITLE
Adds iframe with all the Consells of Horta District

### DIFF
--- a/public/consells/horta.html
+++ b/public/consells/horta.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Targetes Decidim Consells de Barri H-G</title>
+    <style>
+      @import url("https://ajuntament.barcelona.cat/eixample/sites/all/themes/bcn_bootstrap/css/style.css?q0ye9t");
+    </style>
+  </head>
+  <body>
+  <div class="container">
+
+    <div class="row">
+      <div class="col-sm-4">
+        <script src="https://www.decidim.barcelona/assemblies/consellBaixGuinardo/embed.js"></script>
+        <noscript><iframe src="https://www.decidim.barcelona/assemblies/consellBaixGuinardo/embed.html" frameborder="0" scrolling="vertical"></iframe></noscript>
+      </div>
+      <div class="col-sm-4">
+        <script src="https://www.decidim.barcelona/assemblies/consellCanBaro/embed.js"></script>
+        <noscript><iframe src="https://www.decidim.barcelona/assemblies/consellCanBaro/embed.html" frameborder="0" scrolling="vertical"></iframe></noscript>
+      </div>
+      <div class="col-sm-4">
+        <script src="https://www.decidim.barcelona/assemblies/consellGuinardo/embed.js"></script>
+        <noscript><iframe src="https://www.decidim.barcelona/assemblies/consellGuinardo/embed.html" frameborder="0" scrolling="vertical"></iframe></noscript>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-4">
+        <script src="https://www.decidim.barcelona/assemblies/consellFontdenFargues/embed.js"></script>
+        <noscript><iframe src="https://www.decidim.barcelona/assemblies/consellFontdenFargues/embed.html" frameborder="0" scrolling="vertical"></iframe></noscript>
+      </div>
+      <div class="col-sm-4">
+        <script src="https://www.decidim.barcelona/assemblies/consellCarmel/embed.js"></script>
+        <noscript><iframe src="https://www.decidim.barcelona/assemblies/consellCarmel/embed.html" frameborder="0" scrolling="vertical"></iframe></noscript>
+      </div>
+      <div class="col-sm-4">
+        <script src="https://www.decidim.barcelona/assemblies/consellTeixonera/embed.js"></script>
+        <noscript><iframe src="https://www.decidim.barcelona/assemblies/consellTeixonera/embed.html" frameborder="0" scrolling="vertical"></iframe></noscript>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-4">
+        <script src="https://www.decidim.barcelona/assemblies/consellStGenisAgudells/embed.js"></script>
+        <noscript><iframe src="https://www.decidim.barcelona/assemblies/consellStGenisAgudells/embed.html" frameborder="0" scrolling="vertical"></iframe></noscript>
+      </div>
+      <div class="col-sm-4">
+        <script src="https://www.decidim.barcelona/assemblies/consellMontbau/embed.js"></script>
+        <noscript><iframe src="https://www.decidim.barcelona/assemblies/consellMontbau/embed.html" frameborder="0" scrolling="vertical"></iframe></noscript>
+      </div>
+      <div class="col-sm-4">
+        <script src="https://www.decidim.barcelona/assemblies/consellVallHebron/embed.js"></script>
+        <noscript><iframe src="https://www.decidim.barcelona/assemblies/consellVallHebron/embed.html" frameborder="0" scrolling="vertical"></iframe></noscript>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-4">
+        <script src="https://www.decidim.barcelona/assemblies/consellClota/embed.js"></script>
+        <noscript><iframe src="https://www.decidim.barcelona/assemblies/consellClota/embed.html" frameborder="0" scrolling="vertical"></iframe></noscript>
+      </div>
+      <div class="col-sm-4">
+        <script src="https://www.decidim.barcelona/assemblies/consellHorta/embed.js"></script>
+        <noscript><iframe src="https://www.decidim.barcelona/assemblies/consellHorta/embed.html" frameborder="0" scrolling="vertical"></iframe></noscript>
+      </div>
+    </div>
+
+  </div>
+  </body>
+</html>


### PR DESCRIPTION
#### :tophat: What? Why?

On Decidim Barcelona we need to integrate with other websites of the City Hall. Regarding the Assemblies feature, we need to put an iframe with all the neighbourhoods (sub assemblies) belonging to a given district (assembly). 

Example of where this would be visible: https://ajuntament.barcelona.cat/horta-guinardo/ca/lajuntament/participacio/consell-de-barri 

As this is not needed for other instances we're planning on making an static HTML with all the iframes so it's better for the developers on barcelona.cat 

We wanted to test this Proof of Concept before we deploy this to the rest of districts. 
