### PR TITLE
Make decidim-barcelona Etherpad configurable.

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -26,6 +26,10 @@ Decidim.configure do |config|
 
   config.timestamp_service = "TimestampService"
   config.pdf_signature_service = "PdfSignatureBarcelona"
+
+  if Rails.application.secrets.etherpad[:server].present?
+    config.etherpad = Rails.application.secrets.etherpad
+  end
 end
 
 Decidim::Verifications.register_workflow(:census_authorization_handler) do |auth|

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -46,6 +46,9 @@ default: &default
   pdf_certificate: <%= ENV["PDF_CERTIFICATE"].to_s.dump %>
   pdf_signer_certificate: <%= ENV["PDF_SIGNER_CERTIFICATE"].to_s.dump %>
   pdf_signer_private_key: <%= ENV["PDF_SIGNER_PRIVATE_KEY"].to_s.dump %>
+  etherpad:
+    server: <%= ENV["ETHERPAD_SERVER"] %>
+    api_key: <%= ENV["ETHERPAD_API_KEY"] %>
 
 development:
   <<: *default


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds configuration options so decidim-barcelona can be integrated with EtherPad.
