### PR TITLE
Use geocoder v1.5.2 to stay with old Here maps Api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "sprockets", "~> 3.7", "< 4"
 gem "virtus-multiparams"
 gem "wicked_pdf"
 gem "wkhtmltopdf-binary"
+gem "geocoder", "~> 1.5.2"
 
 gem 'uglifier'
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,7 +429,7 @@ GEM
       activesupport (>= 4.1, < 6.0)
       railties (>= 4.1, < 6.0)
       tzinfo (~> 1.2, >= 1.2.2)
-    geocoder (1.6.0)
+    geocoder (1.5.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     graphiql-rails (1.4.11)
@@ -829,6 +829,7 @@ DEPENDENCIES
   deface
   faker
   fog-aws
+  geocoder (~> 1.5.2)
   letter_opener_web
   listen
   lograge

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -752,6 +752,8 @@ ActiveRecord::Schema.define(version: 2020_01_09_082243) do
     t.index ["day"], name: "index_decidim_metrics_on_day"
     t.index ["decidim_category_id"], name: "index_decidim_metrics_on_decidim_category_id"
     t.index ["decidim_organization_id"], name: "index_decidim_metrics_on_decidim_organization_id"
+    t.index ["metric_type", "decidim_organization_id", "participatory_space_type", "participatory_space_id", "day", "decidim_category_id", "related_object_type", "related_object_id"], name: "idx_metric_by_type_org_space_day_cat_obj"
+    t.index ["metric_type", "decidim_organization_id", "participatory_space_type", "participatory_space_id"], name: "idx_metric_type_by_org_space"
     t.index ["metric_type"], name: "index_decidim_metrics_on_metric_type"
     t.index ["participatory_space_type", "participatory_space_id"], name: "index_metric_on_participatory_space_id_and_type"
     t.index ["related_object_type", "related_object_id"], name: "index_metric_on_related_object_id_and_type"


### PR DESCRIPTION
#### :tophat: What? Why?
Here maps web services also change the way clients authenticate. New accounts can only use
`api_key` authentication whether old accounts used `app_id` and `app_code`.

Geocoder gem changes to the new api since version 1.6.0.
