### PR TITLE
Temporal fix in notifications when create debate events exist

### DIFF
--- a/lib/decidim/events/author_event.rb
+++ b/lib/decidim/events/author_event.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Events
+    # This module is used to be included in event classes inheriting from SimpleEvent
+    # whose resource has an author.
+    #
+    # It adds the author_name, author_nickname, author_path and author_url to the i18n interpolations.
+    module AuthorEvent
+      extend ActiveSupport::Concern
+
+      included do
+        i18n_attributes :author_name, :author_nickname, :author_path, :author_url
+
+        def author_nickname
+          author_presenter&.nickname.to_s
+        end
+
+        def author_name
+          author_presenter&.name.to_s
+        end
+
+        def author_path
+          author_presenter&.profile_path.to_s
+        end
+
+        def author_url
+byebug
+          author_presenter&.profile_url.to_s
+        end
+
+        def author_presenter
+          return unless author
+byebug
+          @author_presenter ||= "#{resource.class.parent}::OfficialAuthorPresenter".constantize.new
+        end
+
+        def author
+          return unless resource.respond_to?(:author)
+          return unless resource.author.is_a?(Decidim::UserBaseEntity)
+
+          resource.author
+        end
+      end
+    end
+  end
+end

--- a/lib/decidim/events/author_event.rb
+++ b/lib/decidim/events/author_event.rb
@@ -25,13 +25,17 @@ module Decidim
         end
 
         def author_url
-          author_presenter&.profile_url.to_s
+          author_presenter.try(:profile_url)&.to_s
         end
 
         def author_presenter
           return unless author
 
-          @author_presenter ||= "#{resource.class.parent}::OfficialAuthorPresenter".constantize.new
+          @author_presenter ||= if resource.respond_to?(:official?) && resource.official?
+            "#{resource.class.parent}::OfficialAuthorPresenter".constantize.new
+          else
+            resource.try(:user_group)&.presenter || author.presenter
+          end
         end
 
         def author

--- a/lib/decidim/events/author_event.rb
+++ b/lib/decidim/events/author_event.rb
@@ -25,13 +25,12 @@ module Decidim
         end
 
         def author_url
-byebug
           author_presenter&.profile_url.to_s
         end
 
         def author_presenter
           return unless author
-byebug
+
           @author_presenter ||= "#{resource.class.parent}::OfficialAuthorPresenter".constantize.new
         end
 

--- a/lib/decidim/events/author_event.rb
+++ b/lib/decidim/events/author_event.rb
@@ -39,8 +39,7 @@ module Decidim
         end
 
         def author
-          return unless resource.respond_to?(:author)
-          return unless resource.author.is_a?(Decidim::UserBaseEntity)
+          return unless resource.respond_to?(:author) && resource.author.is_a?(Decidim::UserBaseEntity)
 
           resource.author
         end

--- a/spec/features/remove_overrides_spec.rb
+++ b/spec/features/remove_overrides_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Overrides" do
+  scenario "remove override to fix created debates notifications" do
+    # remove lib/decidim/events/author_event.rb after https://github.com/decidim/decidim/issues/6091 is fixed
+    expect(Decidim.version).to be < "0.22"
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Override `author_event` in order to solve a bug when sending a new debate notification to admin/users, due to a bad use of a presenter.

#### :pushpin: Related Issues
- Related to #?
- Fixes [DECIDIM-126](https://jira.bcn.cat/browse/DECIDIM-126)

#### :clipboard: Subtasks
- [x] Add test
