### PR TITLE
Remove newrelic-rpm gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ group :production do
   gem "sidekiq"
   gem "rails_12factor"
   gem "fog-aws"
-  gem "newrelic_rpm"
   gem "dalli"
   gem "sentry-raven"
   gem 'rack-ssl-enforcer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -554,7 +554,6 @@ GEM
     multipart-post (2.1.1)
     mustache (1.1.1)
     netrc (0.11.0)
-    newrelic_rpm (6.8.0.360)
     nio4r (2.5.2)
     nobspw (0.6.1)
     nokogiri (1.10.9)
@@ -858,7 +857,6 @@ DEPENDENCIES
   letter_opener_web
   listen
   lograge
-  newrelic_rpm
   origami
   progressbar
   puma


### PR DESCRIPTION
#### :tophat: What? Why?
To reduce memory footprint `newrelic-rpm` gem is being removed.
This gem is not being used since new-relic is neither being used.

