### PR TITLE
Take into account more kinds of resources in author_presenter

### DIFF
--- a/lib/decidim/events/author_event.rb
+++ b/lib/decidim/events/author_event.rb
@@ -31,11 +31,19 @@ module Decidim
         def author_presenter
           return unless author
 
-          @author_presenter ||= if resource.respond_to?(:official?) && resource.official?
-            "#{resource.class.parent}::OfficialAuthorPresenter".constantize.new
-          else
-            resource.try(:user_group)&.presenter || author.presenter
+          @author_presenter ||= if official? && (resource.is_a?(Decidim::Proposals::Proposal) || resource.is_a?(Decidim::Debates::Debate))
+                                  "#{resource.class.parent}::OfficialAuthorPresenter".constantize.new
+                                elsif resource.respond_to?(:user_group)
+                                  resource.user_group&.presenter
+                                elsif author.respond_to?(:presenter)
+                                  author.presenter
+                                else
+                                  Decidim::UserPresenter.new(author)
           end
+        end
+
+        def official?
+          resource.respond_to?(:official?) && resource.official?
         end
 
         def author


### PR DESCRIPTION
#### :tophat: What? Why?
We've found that there are more events related to resources that must be controlled in notifications list.
When fixing the case for "created debate" notifications the "inpiring" source code for the override, taken from `coauthorships_cell` was not taking into account other resources that appear in notifications, like official meetings.

#### :pushpin: Related Issues
- Related to #307
- Fixes #307

#### :clipboard: Subtasks
- [x] Subtask 1
- [ ] Subtask 2

### :camera: Screenshots (optional)
![Description](URL)

#### :ghost: GIF
![]()
