### PR TITLE
Upgrade geocoder to use the new Here API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "sprockets", "~> 3.7", "< 4"
 gem "virtus-multiparams"
 gem "wicked_pdf"
 gem "wkhtmltopdf-binary"
-gem "geocoder", "~> 1.5.2"
+gem "geocoder", "~> 1.6.1"
 
 gem 'uglifier'
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,7 +452,7 @@ GEM
       activesupport (>= 4.1, < 6.0)
       railties (>= 4.1, < 6.0)
       tzinfo (~> 1.2, >= 1.2.2)
-    geocoder (1.5.2)
+    geocoder (1.6.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     graphiql-rails (1.4.11)
@@ -856,7 +856,7 @@ DEPENDENCIES
   deface
   faker (= 1.9.5)
   fog-aws
-  geocoder (~> 1.5.2)
+  geocoder (~> 1.6.1)
   letter_opener_web
   listen
   lograge

--- a/app.json
+++ b/app.json
@@ -28,10 +28,7 @@
     "ANALYTICS": {
       "required": true
     },
-    "HERE_APP_ID": {
-      "required": true
-    },
-    "HERE_APP_CODE": {
+    "HERE_API_KEY": {
       "required": true
     },
     "HEROKU_APP_NAME": {

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -14,9 +14,8 @@ Decidim.configure do |config|
 
   if Rails.application.secrets.geocoder
     config.geocoder = {
-      static_map_url: "https://image.maps.cit.api.here.com/mia/1.6/mapview",
-      here_app_id: Rails.application.secrets.geocoder[:here_app_id],
-      here_app_code: Rails.application.secrets.geocoder[:here_app_code]
+      static_map_url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview",
+      here_api_key: Rails.application.secrets.geocoder[:here_api_key]
     }
   end
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -39,8 +39,7 @@ default: &default
       client_id: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_ID"] %>
       client_secret: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_SECRET"] %>
   geocoder:
-    here_app_id: <%= ENV["HERE_APP_ID"] %>
-    here_app_code: <%= ENV["HERE_APP_CODE"] %>
+    here_api_key: <%= ENV["HERE_API_KEY"] %>
   timestamp_service_url: "<%= ENV['TIMESTAMP_SERVICE_URL'] %>"
   signature_certificate_password: "<%= ENV['SIGNATURE_CERTIFICATE_PASSWORD'] %>"
   pdf_certificate: <%= ENV["PDF_CERTIFICATE"].to_s.dump %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -52,10 +52,14 @@ default: &default
 development:
   <<: *default
   secret_key_base: e3efe0351af320dda7a3daf90a805a68e94d093cfc57a94bf9c42f3f1732fac32dd4656f435e385f1ea7789ff5e387a6313d1db2a3b11e9dd030293158bfdc9b
+  geocoder:
+    here_api_key: 1234123412341234
 
 test:
   <<: *default
   secret_key_base: 4a6fd36ca5634dbf42f63331b1a236a041976561ec314414d1750f33ef691dd3705ff2828a607d98bee0ba492e11281a33e736c71e959ab04c76679e74ecb564
+  geocoder:
+    here_api_key: 1234123412341234
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.


### PR DESCRIPTION
#### :tophat: What? Why?
Here maps has deprecated the API that we were currently using via `geocoder` < 1.5. To use the new Here API, we must upgrade to `geocoder` >= 1.6. To keep the gem up to date with security fixes we must upgrade.

This PR upgrades `geocoder` to use Decidim with the new Here API. It also contains the required configuration change for the credentials.
