### PR TITLE
feat(budgets): add PAM 2020 budgets workflow

### DIFF
--- a/config/initializers/decidim_budgets.rb
+++ b/config/initializers/decidim_budgets.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require "budgets_workflow_pam2020"
+Decidim::Budgets.workflows[:pam2020] = BudgetsWorkflowPam2020

--- a/config/locales/decidim_budgets_workflows_en.yml
+++ b/config/locales/decidim_budgets_workflows_en.yml
@@ -1,0 +1,8 @@
+en:
+  decidim:
+    components:
+      budgets:
+        settings:
+          global:
+            workflow_choices:
+              pam2020: "PAM 2020: allows to Vote in the participant's district and in another of free choice."

--- a/lib/budgets_workflow_pam2020.rb
+++ b/lib/budgets_workflow_pam2020.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Specific Workflow for Barcelona's 2020 PAM
+class BudgetsWorkflowPam2020 < Decidim::Budgets::Workflows::Base
+  PAM2020AUTHORIZATIONHANDLER = 'census_authorization_handler'
+
+  # The budget resource in the user's scope is highlighted.
+  def highlighted?(resource)
+    return unless user_scope_resource && !voted?(user_scope_resource)
+
+    resource == user_scope_resource
+  end
+
+  # Can vote in the budget resource in the user's scope
+  # and in an extra budget resource out of its scope
+  def vote_allowed?(resource, consider_progress = true)
+    return true if resource == user_scope_resource
+
+    resources_with_order = voted
+    resources_with_order += progress if consider_progress
+
+    (resources_with_order - [user_scope_resource, resource]).empty?
+  end
+
+  # The user can change of mind and change the vote on these budget resources
+  #
+  # Returns Array.
+  def discardable
+    (voted + progress) - [user_scope_resource]
+  end
+
+  # The user can vote on maximum 2 budget resources
+  #
+  # Returns Boolean.
+  def limit_reached?
+    (voted + progress).count < 3
+  end
+
+  private
+
+  # Returns Object (Authorization).
+  def user_authorization
+    @user_authorization ||= Decidim::Authorization.find_by(
+      name: PAM2020AUTHORIZATIONHANDLER,
+      user: user
+    )
+  end
+
+  # The budget resources the user can and should vote on
+  #
+  # Returns Object (Decidim::Budgets:Budget).
+  def user_scope_resource
+    return unless user_authorization_scope
+
+    @user_scope_resource ||= budgets.each do |resource|
+      return resource if resource.scope == user_authorization_scope
+    end
+  end
+
+  # The user's scope from the verifcation
+  #
+  # Returns Object (Scope).
+  def user_authorization_scope
+    return unless user_authorization
+
+    @user_authorization_scope ||= Decidim::Scope.find_by(
+      "name->>'ca' = '#{user_authorization.metadata['scope']}'"
+    )
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Add the PAM 2020 budgets workflow, allows to Vote in the participant's district and in another of free choice.

⚠️ `Decidim::Budgets.workflows` available on **Decidim 0.23.0**

#### :pushpin: Related Issues

- Related to https://github.com/decidim/decidim/issues/5711

