### PR TITLE
Make finding of first proposal img consistent between postgres versions

### DIFF
--- a/app/overrides/cells/decidim/proposals/proposal_m_cell_decorator.rb
+++ b/app/overrides/cells/decidim/proposals/proposal_m_cell_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# When rendering proposal cards created with an image and an attachment together depending on
+# PostgreSql version the image is rendered or not.
+# This is because attachments have a default scope that orders by weight and all attachments have the same weight.
+# Then PostgreSql orders differently between < 12 versions and higher.
+# This decorator avoids this inconsistent behaviour.
+
+Decidim::Proposals::ProposalMCell.class_eval do
+  def has_image?
+    model.component.settings.allow_card_image && model.attachments.find_by("content_type like '%image%'").present?
+  end
+
+  def resource_image_path
+    @resource_image_path ||= has_image? ? model.attachments.find_by("content_type like '%image%'").url : nil
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,12 @@ module DecidimBarcelona
     # Locales
     config.i18n.available_locales = %w(ca es)
     config.i18n.default_locale = :ca
+
+    # Make decorators available
+    config.to_prepare do
+      Dir.glob(Rails.root + 'app/overrides/**/*_decorator*.rb').each do |file|
+        require_dependency(file)
+      end
+    end
   end
 end

--- a/spec/features/remove_overrides_spec.rb
+++ b/spec/features/remove_overrides_spec.rb
@@ -22,7 +22,7 @@ describe "Overrides" do
     expect(Decidim.version).to be < "0.22"
   end
 
-  describe "remove consistent sorting of proposal attachments" do
+  it "remove consistent sorting of proposal attachments" do
     # remove app/overrides/cells/decidim/proposals/proposal_m_cell_decorator.rb
     expect(Decidim.version).to be < "0.24"
   end

--- a/spec/features/remove_overrides_spec.rb
+++ b/spec/features/remove_overrides_spec.rb
@@ -21,4 +21,9 @@ describe "Overrides" do
     # - decidim.meetings.admin.meetings.destroy.invalid.proposals_count.other
     expect(Decidim.version).to be < "0.22"
   end
+
+  describe "remove consistent sorting of proposal attachments" do
+    # remove app/overrides/cells/decidim/proposals/proposal_m_cell_decorator.rb
+    expect(Decidim.version).to be < "0.24"
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
We've found that depending on the versions of the PostgreSql database the ordering in which the attachments are returned by the `Attachment` default scope which is:
```ruby
default_scope { order(arel_table[:weight].asc) }
```

for this scope, when all results have the same wight, PostgreSql versions prior to v12 return results finally ordered by `id` DESC. For PostgreSql versions after v12, results having the same weight are finally ordered by `id` but ASC.

Wen the card of a Proposal was checking if the first attachment is an image, it was behaving differently depending on the PostgreSql version.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] fix
- [x] remove override on decidim v0.24

### :camera: Screenshots (optional)
![Description](URL)

#### :ghost: GIF
![]()
