### PR TITLE
Avoid meetings directory collision with legacy routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
                                                                   }
 
     get "/:process_slug/:component_name/(:resource_id)", to: redirect(DecidimLegacyRoutes.new(component_translations)),
-                                                         constraints: { process_id: /[^0-9]+/, component_name: Regexp.new(component_translations.keys.join("|")) }
+                                                         constraints: { process_slug: /(?!meetings).*/, process_id: /[^0-9]+/, component_name: Regexp.new(component_translations.keys.join("|")) }
 
     get "/:component_name/:resource_id", to: redirect { |params, _request|
       component_translation = component_translations[params[:component_name].to_sym]
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
       process = component.participatory_space
       component_manifest_name = component.manifest_name
       "/processes/#{process.id}/f/#{component.id}/#{component_manifest_name}/#{resource.id}"
-    }, constraints: { component_name: Regexp.new(component_translations.keys.join("|")) }
+    }, constraints: { component_name: Regexp.new(component_translations.keys.join("|")), resource_id: /(?!meetings).*/ }
   end
 
   authenticate :user, ->(u) { u.admin? } do

--- a/spec/routing/redirections_spec.rb
+++ b/spec/routing/redirections_spec.rb
@@ -3,6 +3,7 @@ require "decidim/dev/test/spec_helper"
 require "decidim/core/test/factories"
 require "decidim/participatory_processes/test/factories"
 require "decidim/proposals/test/factories"
+require "decidim/meetings/test/factories"
 
 describe "routing redirections", type: :request do
   let!(:organization) { create(:organization, host: "decidim.barcelona" )}
@@ -35,6 +36,11 @@ describe "routing redirections", type: :request do
       it "redirects index paths inside the old step structure" do
         expect(get("/test-process/123/proposals/"))
           .to redirect_to("/processes/#{participatory_process.id}/f/#{component.id}")
+      end
+
+      it "does not redirect when paginating the meetings directory" do
+        create(:meeting_component, organization: organization)
+        expect { get("/meetings/meetings?page=2") }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
When browsing to pages of the meetings directory, i.e. `/meetings/meetings?page=2` this url collides with the regacy routes redirects for top-level proposals.

This PR tries to fix this by adding constraints to the false matches.