### PR TITLE
Refine regexp in legacy routes constraints to avoid false positives

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
                                                                   }
 
     get "/:process_slug/:component_name/(:resource_id)", to: redirect(DecidimLegacyRoutes.new(component_translations)),
-                                                         constraints: { process_slug: /(?!meetings).*/, process_id: /[^0-9]+/, component_name: Regexp.new(component_translations.keys.join("|")) }
+                                                         constraints: { process_slug: /(?!meetings)[^\/]*/, process_id: /[^0-9]+/, component_name: Regexp.new(component_translations.keys.join("|")) }
 
     get "/:component_name/:resource_id", to: redirect { |params, _request|
       component_translation = component_translations[params[:component_name].to_sym]
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
       process = component.participatory_space
       component_manifest_name = component.manifest_name
       "/processes/#{process.id}/f/#{component.id}/#{component_manifest_name}/#{resource.id}"
-    }, constraints: { component_name: Regexp.new(component_translations.keys.join("|")), resource_id: /(?!meetings).*/ }
+    }, constraints: { component_name: Regexp.new(component_translations.keys.join("|")), resource_id: /(?!meetings)[^\/]*/ }
   end
 
   authenticate :user, ->(u) { u.admin? } do

--- a/spec/routing/redirections_spec.rb
+++ b/spec/routing/redirections_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 require "decidim/dev/test/spec_helper"
 require "decidim/core/test/factories"
+require "decidim/assemblies/test/factories"
 require "decidim/participatory_processes/test/factories"
 require "decidim/proposals/test/factories"
 require "decidim/meetings/test/factories"
@@ -37,11 +38,6 @@ describe "routing redirections", type: :request do
         expect(get("/test-process/123/proposals/"))
           .to redirect_to("/processes/#{participatory_process.id}/f/#{component.id}")
       end
-
-      it "does not redirect when paginating the meetings directory" do
-        create(:meeting_component, organization: organization)
-        expect { get("/meetings/meetings?page=2") }.not_to raise_error
-      end
     end
 
     context "with the wrong host" do
@@ -51,6 +47,37 @@ describe "routing redirections", type: :request do
 
       it "doesn't redirect" do
         expect { get("/proposals/test-proposal") }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+
+  describe "meetings" do
+    let(:participatory_space) { create(:assembly, organization: organization, slug: "test-assembly") }
+    let!(:component) { create(:meeting_component, participatory_space: participatory_space) }
+    let(:meeting) { create(:meeting, component: component) }
+
+    context "with the right host" do
+      before(:each) do
+        host! organization.host
+      end
+
+      it "does not redirect when paginating the meetings directory" do
+        expect { get("/meetings/meetings?page=2") }.not_to raise_error
+      end
+
+      context "when browsing the meetings of an assembly" do
+
+        it "does not try to redirect" do
+          expect { get("/assemblies/#{participatory_space.slug}/f/#{component.id}/meetings/#{meeting.id}") }.not_to raise_error
+        end
+      end
+
+      context "when browsing the meetings of a process" do
+        let!(:participatory_space) { create(:participatory_process, organization: organization, slug: "test-process") }
+
+        it "does not try to redirect" do
+          expect { get("/processes/#{participatory_space.slug}/f/#{component.id}/meetings/#{meeting.id}") }.not_to raise_error
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Due to https://github.com/AjuntamentdeBarcelona/decidim-barcelona/pull/329 routes with the format `assemblies/barrilaprosperitat/f/2559/meetings/3755` were being matched by legacy routes.
This PR refines the regular expression to avoid this situation.

#### :pushpin: Related Issues
- Related to #329