### PR TITLE
Fix in upcoming meetings show only visible meetings

### DIFF
--- a/app/overrides/cells/decidim/meetings/upcoming_events_cell_decorator.rb
+++ b/app/overrides/cells/decidim/meetings/upcoming_events_cell_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Decidim::Meetings::ContentBlocks::UpcomingEventsCell.class_eval do
+  def upcoming_events
+    @upcoming_events ||= Decidim::Meetings::Meeting
+                         .includes(component: :participatory_space)
+                         .where(component: meeting_components)
+                         .visible_meeting_for(current_user)
+                         .where("end_time >= ?", Time.current)
+                         .order(start_time: :asc)
+                         .limit(limit)
+  end
+end

--- a/spec/features/remove_overrides_spec.rb
+++ b/spec/features/remove_overrides_spec.rb
@@ -34,4 +34,9 @@ describe "Overrides" do
     # app/overrides/cells/decidim/meetings/highlighted_meetings_for_component_cell_decorator.rb
     expect(Decidim.version).to be < "0.22"
   end
+
+  it "remove: Fix accept invitation to private meetings" do
+    # app/overrides/cells/decidim/meetings/upcoming_events_cell_decorator.rb
+    expect(Decidim.version).to be < "0.22"
+  end
 end

--- a/spec/features/remove_overrides_spec.rb
+++ b/spec/features/remove_overrides_spec.rb
@@ -37,6 +37,6 @@ describe "Overrides" do
 
   it "remove: Fix accept invitation to private meetings" do
     # app/overrides/cells/decidim/meetings/upcoming_events_cell_decorator.rb
-    expect(Decidim.version).to be < "0.22"
+    expect(Decidim.version).to be < "0.23"
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR ports the fix in PR #6778 by using decorators while this app is not upgraded to v0.23:
"When there are private meetings marked as non transparent, they are showed on upcoming meetings if the current user is logged. No matters if the user is registered to them."

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [x] Subtask 1
- [ ] Subtask 2

### :camera: Screenshots (optional)
![Description](URL)

#### :ghost: GIF

