### PR TITLE
Add scope_id to census auths

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/decidim/decidim
-  revision: 8cc6df7f0bdb91373546194e3fe955ccbdaa14d1
+  revision: 26470b2568c6c39aa22270af5bb01aaea7a64a8f
   branch: release/0.23-stable
   specs:
     decidim (0.23.2)
@@ -483,7 +483,7 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.8.8)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.33)
       activesupport (>= 4.0.2)
@@ -558,7 +558,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.1104)
+    mime-types-data (3.2021.0212)
     mimemagic (0.3.5)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
@@ -567,7 +567,7 @@ GEM
     mixlib-cli (2.1.8)
     mixlib-config (3.0.9)
       tomlrb
-    mixlib-shellout (3.2.2)
+    mixlib-shellout (3.2.5)
       chef-utils
     msgpack (1.3.3)
     multi_json (1.15.0)

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -37,6 +37,7 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
       date_of_birth: date_of_birth&.strftime("%Y-%m-%d"),
       postal_code: postal_code,
       scope: scope.name["ca"],
+      scope_id: scope.id,
       extras: {
         gender: gender
       }

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -14,9 +14,10 @@ Decidim.configure do |config|
   end
 
   if Rails.application.secrets.geocoder
-    config.geocoder = {
-      static_map_url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview",
-      here_api_key: Rails.application.secrets.geocoder[:here_api_key]
+    config.maps = {
+      provider: :here,
+      api_key: Rails.application.secrets.geocoder[:here_api_key],
+      static: { url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview" }
     }
   end
 

--- a/db/migrate/20210217110107_add_scope_id_to_census_authorizations.rb
+++ b/db/migrate/20210217110107_add_scope_id_to_census_authorizations.rb
@@ -1,0 +1,29 @@
+class AddScopeIdToCensusAuthorizations < ActiveRecord::Migration[5.2]
+  def up
+    scopes = Decidim::Scope.all
+    scopes_by_name = scopes.map{ |scope| [scope.name["ca"], scope.id] }.to_h
+
+    Decidim::Authorization.where(name: "census_authorization_handler").find_each do |auth|
+      scope_name = cleanup_scope_name(auth.metadata["scope"])
+      scope_id = scopes_by_name[scope_name]
+
+      raise "ERROR: #{scope_name} scope not found for auth #{auth.id}" unless scope_id rescue byebug
+      auth.metadata["scope"] = scope_name
+      auth.metadata["scope_id"] = scope_id
+      auth.save
+    end
+  end
+
+  def down; end
+
+  def cleanup_scope_name(name)
+    case name
+    when "Horta-Guinardó"
+      "Horta - Guinardó"
+    when "Sants-Montjuïc"
+      "Sants - Montjuïc"
+    else
+      name
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_12_095544) do
+ActiveRecord::Schema.define(version: 2021_02_17_110107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"

--- a/spec/services/census_authorization_handler_spec.rb
+++ b/spec/services/census_authorization_handler_spec.rb
@@ -13,7 +13,7 @@ describe CensusAuthorizationHandler do
   let(:date_of_birth) { Date.civil(1987, 9, 17) }
   let(:scope_id) { 123 }
   let(:gender) { "foo" }
-  let(:scope) { double(code: "1", name: { "ca" => "Ciutat Vella" }) }
+  let(:scope) { double(id: 999, code: "1", name: { "ca" => "Ciutat Vella" }) }
   let(:user) { create :user }
   let(:params) do
     {
@@ -181,8 +181,12 @@ describe CensusAuthorizationHandler do
       expect(subject.metadata).to include(postal_code: "08001")
     end
 
-    it "includes the scope" do
+    it "includes the scope name" do
       expect(subject.metadata).to include(scope: "Ciutat Vella")
+    end
+
+    it "includes the scope id" do
+      expect(subject.metadata).to include(scope_id: scope.id)
     end
 
     it "includes the user gender" do
@@ -221,6 +225,7 @@ describe CensusAuthorizationHandler do
       let(:metadata) do
         {
           scope: scope.name["ca"],
+          scope_id: scope.id,
           postal_code: form.postal_code,
           date_of_birth: form.date_of_birth&.strftime("%Y-%m-%d"),
           extras: {


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes a bug where in some specific cases users couldn't sign initiatives because the authorization metadata was missing a key.

This is in sync with https://github.com/decidim/decidim/pull/7407

#### :pushpin: Related Issues
None