### PR TITLE
Add purge unused verifications for ephemeral users task

### DIFF
--- a/decidim-ephemeral_participation/lib/tasks/purge_unused_verifications.rake
+++ b/decidim-ephemeral_participation/lib/tasks/purge_unused_verifications.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :ephemeral_participation do
+    desc "Purge verifications created but not used, to allow participants to try it again with another ephemeral User"
+    task purge_unused_verifications: :environment do
+      unused_autorizations.find_each do |authorization|
+        conflicts_for(authorization.user).delete_all
+        authorization.destroy!
+      end
+    end
+
+    def unused_autorizations
+      Decidim::Authorization
+    end
+
+    def conflicts_for(user)
+      Decidim::Conflict.where(managed_user: user, solved: false).or(
+        Decidim::Conflict.where(user: user, solved: false)
+      )
+    end
+  end
+end

--- a/decidim-ephemeral_participation/lib/tasks/purge_unused_verifications.rake
+++ b/decidim-ephemeral_participation/lib/tasks/purge_unused_verifications.rake
@@ -24,7 +24,7 @@ namespace :decidim do
 
     def conflicts_for(user)
       Decidim::Conflict.where(managed_user: user, solved: false).or(
-        Decidim::Conflict.where(user: user, solved: false)
+        Decidim::Conflict.where(current_user: user, solved: false)
       )
     end
   end

--- a/decidim-ephemeral_participation/lib/tasks/purge_unused_verifications.rake
+++ b/decidim-ephemeral_participation/lib/tasks/purge_unused_verifications.rake
@@ -4,10 +4,14 @@ namespace :decidim do
   namespace :ephemeral_participation do
     desc "Purge verifications created but not used, to allow participants to try it again with another ephemeral User"
     task purge_unused_verifications: :environment do
+      puts "Deleting #{unused_autorizations.count} authorizations... "
+
+      conflicts = 0
       unused_autorizations.find_each do |authorization|
-        conflicts_for(authorization.user).delete_all
+        conflicts += conflicts_for(authorization.user).delete_all
         authorization.destroy!
       end
+      puts "and #{conflicts} related conflicts.\n"
     end
 
     def unused_autorizations

--- a/decidim-ephemeral_participation/lib/tasks/purge_unused_verifications.rake
+++ b/decidim-ephemeral_participation/lib/tasks/purge_unused_verifications.rake
@@ -11,7 +11,11 @@ namespace :decidim do
     end
 
     def unused_autorizations
-      Decidim::Authorization
+      Decidim::Authorization.where(user: lost_ephemeral_users)
+    end
+
+    def lost_ephemeral_users
+      Decidim::User.ephemeral_participant.where("updated_at < ?", 12.hours.ago).where("id NOT IN (SELECT decidim_user_id FROM decidim_budgets_orders)")
     end
 
     def conflicts_for(user)


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds a rake task to delete the authorizations and conflicts (if they exist) for ephemeral users that didn't vote on any budgets process.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Subtask 1
- [ ] Subtask 2

### :camera: Screenshots (optional)
![Description](URL)
