### PR TITLE
fix scope picker permissions

### DIFF
--- a/decidim-ephemeral_participation/app/permissions/decidim/ephemeral_participation/ephemeral_participation_permissions.rb
+++ b/decidim-ephemeral_participation/app/permissions/decidim/ephemeral_participation/ephemeral_participation_permissions.rb
@@ -106,7 +106,7 @@ module Decidim
       end
 
       def browsing_public_pages?
-        permission_action.scope == :public && [:read, :list].include?(permission_action.action)
+        permission_action.scope == :public && [:read, :list, :pick].include?(permission_action.action)
       end
 
       def changing_locales?


### PR DESCRIPTION
#### :tophat: What? Why?
Ephemeral participation module should not intervene in the scope picker modal. This fixes that 

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Subtask 1
- [ ] Subtask 2

### :camera: Screenshots (optional)
![Description](URL)
