### PR TITLE
Remove follow button from initiatives card M

### DIFF
--- a/app/lib/decidim/overrides/initiatives/initiative_m_cell.rb
+++ b/app/lib/decidim/overrides/initiatives/initiative_m_cell.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Overrides
+    module Initiatives
+      # This cell overrides the Medium (:m) initiative card
+      # for an given instance of an Initiative
+      module InitiativeMCell
+        def statuses
+          [:creation_date, :comments_count]
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  Decidim::Initiatives::InitiativeMCell.prepend Decidim::Overrides::Initiatives::InitiativeMCell
+end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -59,6 +59,12 @@ checksums = [
     files: {
       "/app/views/decidim/accountability/results/home.html.erb" => "8b8b5073f77299f1f594ca7229874963"
     }
+  },
+  {
+    package: "decidim-initiatives",
+    files: {
+      "/app/cells/decidim/initiatives/initiative_m_cell.rb" => "a20b707d0533dd8883b0bdbf8bc0b2c0"
+    }
   }
 ]
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR removes the [Follow] button from the initiatives card.

#### :pushpin: Related Issues

#### :clipboard: Subtasks


### :camera: Screenshots (optional)

The initiative card without the follow button:
![image](https://user-images.githubusercontent.com/210216/175248885-86ae9715-19b2-4eb6-8f24-7644e2277d65.png)

