### PR TITLE
feat: results added into 'graciazeroespaisfoscos' assembly for home view

### DIFF
--- a/app/views/decidim/accountability/results/home.html.erb
+++ b/app/views/decidim/accountability/results/home.html.erb
@@ -4,7 +4,17 @@
     <% if current_participatory_space.slug.to_s == "PressupostosParticipatius" %>
       <%= render partial: "home_scopes" %>
     <% end %>
-    <%= render partial: "home_categories" %>
+    <% if current_participatory_space.slug.to_s == "graciazeroespaisfoscos" %>
+      <div class="small-12 columns end">
+        <% if results.any?{|r| r.children_count > 0 } %>
+          <%= render partial: "results_parent", locals: { results: results, total_count: results.total_count } %>
+        <% else %>
+          <%= render partial: "results_leaf", locals: { results: results, total_count: results.total_count } %>
+        <% end %>
+      </div>
+    <% else %>
+      <%= render partial: "home_categories" %>
+    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
#### :tophat: What? Why?

For the given specific assembly with no categories, should list all the results.

Fixes: The results of the given assembly without categories "graciazeroespaisfoscos" are now listed in its view. The code was written following the not scalable practice of "PressupostosParticipatius" and this drawback is known by the client.

### :camera: Screenshots (optional)
![Description](URL)
