### PR TITLE
text of responsible declaration in initiatives signature fixed

### DIFF
--- a/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
+++ b/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
@@ -1,0 +1,43 @@
+<div class="callout secondary mb-sm">
+  <p>
+<%= t ".help" %>
+  </p>
+</div>
+<h2 class="section-heading"><%= t(step, scope: "layouts.decidim.initiative_signature_creation_header") %></h2>
+
+<%= render partial: "wizard_steps" %>
+
+<div class="card">
+  <div class="card__content">
+    <%= decidim_form_for(@form, url: next_wizard_path, method: :put, html: { class: "form user_personal_data_signature_form" }) do |f| %>
+      <%= form_required_explanation %>
+      <div>
+        <div class="field">
+          <%= f.text_field :name_and_surname, autofocus: true, required: true %>
+        </div>
+
+        <div class="field">
+          <%= f.text_field :document_number, required: true %>
+        </div>
+
+        <div class="field date">
+          <%= f.date_select :date_of_birth, start_year: 1900, end_year: 16.years.ago.year, default: 35.years.ago, prompt: { day: t(".date_select.day"), month: t(".date_select.month"), year: t(".date_select.year") } %>
+        </div>
+
+        <div class="field">
+          <%= f.text_field :postal_code, required: true %>
+        </div>
+
+        <div class="pb-s">
+          <small class="text-small">
+          <%= decidim_sanitize_editor translated_attribute(extra_data_legal_information) %>
+          </small>
+        </div>
+      </div>
+
+      <div class="actions">
+        <%= f.submit t(".continue"), class: "button expanded" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -64,7 +64,8 @@ checksums = [
     package: "decidim-initiatives",
     files: {
       "/app/cells/decidim/initiatives/initiative_m_cell.rb" => "a20b707d0533dd8883b0bdbf8bc0b2c0",
-      "/app/views/layouts/decidim/_initiative_header_steps.html.erb" => "f1bcd3e7c406a2263d49d0f341930bfc"
+      "/app/views/layouts/decidim/_initiative_header_steps.html.erb" => "f1bcd3e7c406a2263d49d0f341930bfc",
+      "/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb" => "2c3068724ed2986f62bd13994960f39e"
     }
   },
   {


### PR DESCRIPTION
#### :tophat: What? Why?

The responsible declaration text that appears to sign an initiative should show formatted text, and was showing as plain text


### :camera: Screenshots (optional)

![image](https://user-images.githubusercontent.com/118991050/211361224-1db58798-d31f-4e0a-9225-2b46e6a0285c.png)

