### PR TITLE
Hint text, Initiative Signatures Form (Document number)

### DIFF
--- a/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
+++ b/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
@@ -18,6 +18,7 @@
 
         <div class="field">
           <%= f.text_field :document_number, required: true %>
+          <p class="help-text"><%= t('.document_hint') %></p>
         </div>
 
         <div class="field date">

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -182,6 +182,9 @@ ca:
       initiatives:
         supports:
           title: Llistat d'adhesions
+      initiative_signatures:
+        fill_personal_data:
+          document_hint: '* El número de document correspon al document utilizat en la verificació amb el padró (DNI, Passport o NIE).'
     resource_links:
       included_proposals:
         project_proposals: 'Propostes incloses en aquest projecte:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -173,6 +173,9 @@ es:
         verified: Si quieres continuar participando en decidim.barcelona en futuros
           procesos, completa tu registro %{link}
     initiatives:
+      initiative_signatures:
+        fill_personal_data:
+          document_hint: '* El número del documento corresponde al documento utilizado en la verificación contra el padrón (DNI, Pasaporte o NIE).'
       initiatives:
         supports:
           title: Listado de adhesiones


### PR DESCRIPTION
#### :tophat: What? Why?

Document number field should have a hint text giving some extra information.

#### :pushpin: Related Issues
- Related to Decidim-610
- Fixes: Hint text added below document number field and the corresponding translations.

### :camera: Screenshots (optional)
![Captura de pantalla_20230118_095334](https://user-images.githubusercontent.com/71900287/213126584-dbd6cbc4-79b1-4c4f-91e4-34c17a032049.png)
