### PR TITLE
Fix Redis TLS configuration

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/GlobalVars
+$redis = Redis.new(url: ENV["REDIS_URL"], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }) if Rails.env.production?
+# rubocop:enable Style/GlobalVars

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+if Rails.env.production?
+  Sidekiq.configure_server do |config|
+    config.redis = { url: ENV["REDIS_URL"], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+  end
+
+  Sidekiq.configure_client do |config|
+    config.redis = { url: ENV["REDIS_URL"], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Configure Redis to accept messages using a TLS layer required in [Redis 6+ in Heroku](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-ruby).
