### PR TITLE
Disable strict args for sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -8,4 +8,6 @@ if Rails.env.production?
   Sidekiq.configure_client do |config|
     config.redis = { url: ENV["REDIS_URL"], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
   end
+
+  Sidekiq.strict_args!(false)
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Fix error: `ArgumentError (Job arguments to Decidim::EventPublisherJob must be native JSON types` by disabling `strict_args` as specified in the [upgrade notes of Sidekiq 7](https://github.com/mperham/sidekiq/blob/main/docs/7.0-Upgrade.md#strict-arguments).
