### PR TITLE
Videoconference Iframe resized

### DIFF
--- a/app/cells/concerns/decidim/meetings/online_meeting_cell_override.rb
+++ b/app/cells/concerns/decidim/meetings/online_meeting_cell_override.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    module OnlineMeetingCellOverride
+      extend ActiveSupport::Concern
+
+      included do
+        def bcn_iframe?
+          model.online_meeting_url.include?("salavirtual.barcelona.cat")
+        end
+      end
+    end
+  end
+end

--- a/app/cells/decidim/meetings/online_meeting_link/show.erb
+++ b/app/cells/decidim/meetings/online_meeting_link/show.erb
@@ -1,0 +1,44 @@
+<% if online_meeting_url? %>
+  <% if live? || future? %>
+    <div class="card card--secondary">
+      <div class="card__content text-center">
+        <% if live? %>
+          <div class="heading1 text-primary">
+            <%= icon "audio", class: "heading4" %>
+          </div>
+          <div>
+            <strong class="heading5"><%= t("live_event", scope: "decidim.meetings.meetings.show") %></strong>
+            <% unless show_embed? %>
+              <p><small><%= t("micro_camera_permissions_warning", scope: "decidim.meetings.meetings.show") %></small></p>
+            <% end %>
+          </div>
+        <% end %>
+
+        <% if show_embed? && live? %>
+          <div class="<%= "margin-top-3" if live? %> absolutes" style="<%= "height: 1100px" if live? %>">
+            <%== embed_code(request.host) %>
+          </div>
+        <% elsif live? || future? %>
+          <div class="absolutes">
+            <% if live? %>
+              <%= link_to t("join", scope: "decidim.meetings.meetings.show"), live_event_url, target: "_blank", class: "button button--sc" %>
+            <% elsif future? %>
+              <span><%= t("link_closed", scope: "decidim.meetings.meetings.show") %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <div class="card card--secondary">
+    <div class="card__content address">
+      <div class="address__info">
+        <%= icon "timer", role: "img", "aria-hidden": true, remove_icon_class: true, width: 40, height: 70 %>
+        <div class="address__details">
+          <span><%= t("link_available_soon", scope: "decidim.meetings.meetings.show") %></span>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/cells/decidim/meetings/online_meeting_link/show.erb
+++ b/app/cells/decidim/meetings/online_meeting_link/show.erb
@@ -15,7 +15,7 @@
         <% end %>
 
         <% if show_embed? && live? %>
-          <div class="<%= "margin-top-3" if live? %> absolutes" style="<%= "height: 1100px" if live? %>">
+          <div class="<%= "margin-top-3" if live? %> absolutes aspect-ratio-16-9" style="<%= "height: 1100px" if bcn_iframe? %>">
             <%== embed_code(request.host) %>
           </div>
         <% elsif live? || future? %>

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -4,4 +4,5 @@ Rails.application.config.to_prepare do
   Decidim::Initiatives::InitiativeMCell.prepend Decidim::Overrides::Initiatives::InitiativeMCell
   Decidim::Accountability::Result.include(Decidim::Accountability::ResultOverride)
   Decidim::Accountability::ResultsCalculator.include(Decidim::Accountability::ResultsCalculatorOverride)
+  Decidim::Meetings::OnlineMeetingCell.include(Decidim::Meetings::OnlineMeetingCellOverride)
 end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -75,7 +75,8 @@ checksums = [
   {
     package: "decidim-meetings",
     files: {
-      "/app/cells/decidim/meetings/join_meeting_button/show.erb" => "7d85622f4dd6c7a262ab59c53a6aaedf"
+      "/app/cells/decidim/meetings/join_meeting_button/show.erb" => "7d85622f4dd6c7a262ab59c53a6aaedf",
+      "/app/cells/decidim/meetings/online_meeting_link/show.erb" => "9557df6e46040a6395c71c75cd84792c"
     }
   }
 ]

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -76,7 +76,8 @@ checksums = [
     package: "decidim-meetings",
     files: {
       "/app/cells/decidim/meetings/join_meeting_button/show.erb" => "7d85622f4dd6c7a262ab59c53a6aaedf",
-      "/app/cells/decidim/meetings/online_meeting_link/show.erb" => "9557df6e46040a6395c71c75cd84792c"
+      "/app/cells/decidim/meetings/online_meeting_link/show.erb" => "9557df6e46040a6395c71c75cd84792c",
+      "/app/cells/decidim/meetings/online_meeting_cell.rb" => "20564c5da2200ed0c9fe42c457af26cb"
     }
   }
 ]


### PR DESCRIPTION
The videoconference iframe had a 16:9 size, which left part of the iframe content hidden.

#### :pushpin: Related Issues
- Related to: Decidim-657
- Fixes: Father div of that iframe was resized to 1100px only when the meeting is on live.


![Captura de pantalla 2023-03-16 102505](https://user-images.githubusercontent.com/71900287/225578838-082e2d78-2b3e-408f-b4f5-8160736c64eb.png)


