### PR TITLE
Hide Meeting duration if zero

### DIFF
--- a/app/helpers/concerns/decidim/meetings/meetings_helper_override.rb
+++ b/app/helpers/concerns/decidim/meetings/meetings_helper_override.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    module MeetingsHelperOverride
+      extend ActiveSupport::Concern
+
+      included do
+        def search_for_zero_duration_events(agendas_times)
+          agendas_times.any? { |agenda_time| agenda_time[:start_time] - agenda_time[:end_time] == 0 }
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/concerns/decidim/meetings/meetings_helper_override.rb
+++ b/app/helpers/concerns/decidim/meetings/meetings_helper_override.rb
@@ -6,8 +6,21 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
-        def search_for_zero_duration_events(agendas_times)
-          agendas_times.any? { |agenda_time| agenda_time[:start_time] - agenda_time[:end_time] == 0 }
+        # Public: Check if any agenda time has a 0 duration with a depth of two levels
+        # TODO Implementation as a recursive method so that it takes into account higher levels of depth
+        #
+        # agendas - Agenda items for the meeting with zero depth
+        # meeting - The meeting
+        def any_zero_duration_event?(agendas, meeting)
+          agenda_items_times = calculate_start_and_end_time_of_agenda_items(agendas, meeting)
+          agenda_items_times.any? { |agenda_time| agenda_time[:start_time] - agenda_time[:end_time] == 0 } ||
+            agendas.map.with_index do |agenda, index|
+              next unless agenda.agenda_item_children.presence
+
+              parent_start_time = agenda_items_times[index][:start_time]
+              agenda_items_children_times = calculate_start_and_end_time_of_agenda_items(agenda.agenda_item_children, meeting, parent_start_time)
+              agenda_items_children_times.any? { |agenda_children| agenda_children[:start_time] - agenda_children[:end_time] == 0 }
+            end.include?(true)
         end
       end
     end

--- a/app/helpers/concerns/decidim/meetings/meetings_helper_override.rb
+++ b/app/helpers/concerns/decidim/meetings/meetings_helper_override.rb
@@ -13,13 +13,13 @@ module Decidim
         # meeting - The meeting
         def any_zero_duration_event?(agendas, meeting)
           agenda_items_times = calculate_start_and_end_time_of_agenda_items(agendas, meeting)
-          agenda_items_times.any? { |agenda_time| agenda_time[:start_time] - agenda_time[:end_time] == 0 } ||
+          agenda_items_times.any? { |agenda_time| (agenda_time[:start_time] - agenda_time[:end_time]).zero? } ||
             agendas.map.with_index do |agenda, index|
               next unless agenda.agenda_item_children.presence
 
               parent_start_time = agenda_items_times[index][:start_time]
               agenda_items_children_times = calculate_start_and_end_time_of_agenda_items(agenda.agenda_item_children, meeting, parent_start_time)
-              agenda_items_children_times.any? { |agenda_children| agenda_children[:start_time] - agenda_children[:end_time] == 0 }
+              agenda_items_children_times.any? { |agenda_children| (agenda_children[:start_time] - agenda_children[:end_time]).zero? }
             end.include?(true)
         end
       end

--- a/app/views/decidim/meetings/meetings/_meeting_agenda.html.erb
+++ b/app/views/decidim/meetings/meetings/_meeting_agenda.html.erb
@@ -5,7 +5,7 @@
   <div class="card">
     <div class="card__content scroll">
       <% agenda_items_times = calculate_start_and_end_time_of_agenda_items(meeting.agenda.agenda_items.first_class, meeting) %>
-      <% zero_duration = search_for_zero_duration_events(agenda_items_times) %>
+      <% zero_duration = any_zero_duration_event?(meeting.agenda.agenda_items.first_class, meeting) %>
       <% meeting.agenda.agenda_items.first_class.each_with_index do |agenda_item, index| %>
         <h5 class="agenda-item--title heading5">
           <strong><%= translated_attribute(agenda_item.title) %></strong>&nbsp;
@@ -17,7 +17,6 @@
         <% if agenda_item.agenda_item_children.presence %>
           <% parent_start_time = agenda_items_times[index][:start_time] %>
           <% agenda_item_children_times = calculate_start_and_end_time_of_agenda_items(agenda_item.agenda_item_children, meeting, parent_start_time) %>
-          <% zero_duration = search_for_zero_duration_events(agenda_item_children_times) %>
           <% agenda_item.agenda_item_children.each_with_index do |agenda_item_child, index_child| %>
             <h6 class="heading6">
               <strong><%= translated_attribute(agenda_item_child.title) %></strong>&nbsp;

--- a/app/views/decidim/meetings/meetings/_meeting_agenda.html.erb
+++ b/app/views/decidim/meetings/meetings/_meeting_agenda.html.erb
@@ -1,0 +1,32 @@
+<div class="section agenda-section">
+  <div class="flex--sbe">
+    <h2 class="section-heading"><%= translated_attribute(meeting.agenda.title) %></h2>
+  </div>
+  <div class="card">
+    <div class="card__content scroll">
+      <% agenda_items_times = calculate_start_and_end_time_of_agenda_items(meeting.agenda.agenda_items.first_class, meeting) %>
+      <% zero_duration = search_for_zero_duration_events(agenda_items_times) %>
+      <% meeting.agenda.agenda_items.first_class.each_with_index do |agenda_item, index| %>
+        <h5 class="agenda-item--title heading5">
+          <strong><%= translated_attribute(agenda_item.title) %></strong>&nbsp;
+          <span class="text-small"><%= zero_duration ? "" : display_duration_agenda_items(agenda_item.id, index, agenda_items_times) %></span>
+        </h5>
+        <hr class="reset m-none mb-s">
+        <p><%= translated_attribute(agenda_item.description).html_safe %></p>
+
+        <% if agenda_item.agenda_item_children.presence %>
+          <% parent_start_time = agenda_items_times[index][:start_time] %>
+          <% agenda_item_children_times = calculate_start_and_end_time_of_agenda_items(agenda_item.agenda_item_children, meeting, parent_start_time) %>
+          <% zero_duration = search_for_zero_duration_events(agenda_item_children_times) %>
+          <% agenda_item.agenda_item_children.each_with_index do |agenda_item_child, index_child| %>
+            <h6 class="heading6">
+              <strong><%= translated_attribute(agenda_item_child.title) %></strong>&nbsp;
+              <span class="text-small"><%= zero_duration ? "" : display_duration_agenda_items(agenda_item_child.id, index_child, agenda_item_children_times) %></span>
+            </h6>
+            <p><%= translated_attribute(agenda_item_child.description).html_safe %></p>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -7,4 +7,5 @@ Rails.application.config.to_prepare do
   Decidim::Meetings::Meeting.include(Decidim::Meetings::MeetingOverride)
   Decidim::Meetings::MeetingsController.include(Decidim::Meetings::MeetingsControllerOverride)
   Decidim::Meetings::OnlineMeetingCell.include(Decidim::Meetings::OnlineMeetingCellOverride)
+  Decidim::Meetings::MeetingsHelper.include(Decidim::Meetings::MeetingsHelperOverride)
 end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -79,7 +79,9 @@ checksums = [
       "/app/cells/decidim/meetings/online_meeting_link/show.erb" => "9557df6e46040a6395c71c75cd84792c",
       "/app/cells/decidim/meetings/online_meeting_cell.rb" => "20564c5da2200ed0c9fe42c457af26cb",
       "/app/models/decidim/meetings/meeting.rb" => "1386073a688896f7ab5b579c3080cae0",
-      "/app/controllers/decidim/meetings/meetings_controller.rb" => "d0bdba675f1e3df524ac7e834e3a5f37"
+      "/app/controllers/decidim/meetings/meetings_controller.rb" => "d0bdba675f1e3df524ac7e834e3a5f37",
+      "/app/helpers/decidim/meetings/meetings_helper.rb" => "4137d363bfb0d60de112fb765102b72c",
+      "/app/views/decidim/meetings/meetings/_meeting_agenda.html.erb" => "2c5628f8d02af54ad857508e33e212a3"
     }
   }
 ]


### PR DESCRIPTION
#### :tophat: What? Why?
When any of the meeting agenda durations is not known, it shows the same time range.

#### :pushpin: Related Issues
- Related to Decidim-658
- Fixes: Times ranges are now hidden if any of the meeting's agenda times is 0 or any of their sub agenda items.

