### PR TITLE
Anonymize PaperTrail versions table removing users, user groups and a…

### DIFF
--- a/lib/tasks/anonymize.rake
+++ b/lib/tasks/anonymize.rake
@@ -109,5 +109,9 @@ namespace :anonymize do
       )
     end
   end
+
+  task paper_trail: [:check, :environment] do
+    PaperTrail::Version.where(item_type: %w(Decidim::Authorization Decidim::UserBaseEntity Decidim::UserGroup)).delete_all
+  end
 end
 # rubocop:enable Rails/SkipsModelValidations


### PR DESCRIPTION
#### :tophat: What? Why?
Anonymizer task to remove entries on the `versions` table for users, user groups, and authorizations