### PR TITLE
Force number of signatures to older initiatives for a scope that changed the number of them

### DIFF
--- a/app/cells/decidim/initiatives/initiative_m/footer.erb
+++ b/app/cells/decidim/initiatives/initiative_m/footer.erb
@@ -1,0 +1,28 @@
+<div class="card__footer card__footer--spaces">
+  <div class="card__support">
+    <% if model.published? || model.rejected? || model.accepted? %>
+      <div class="card__support__data">
+        <%= cell(
+              "decidim/progress_bar",
+              model.supports_count,
+              total: model.supports_required_for(model.scoped_type.scope),
+              units_name: "decidim.initiatives.initiatives.signatures_count",
+              element_id: "initiative-#{model.id}-signatures-count",
+              small: true
+            ) %>
+      </div>
+    <% else %>
+      <div class="card__support__data"></div>
+    <% end %>
+
+    <% if model.closed? || model.offline_signature_type? %>
+      <%= link_to t("initiatives.initiative.check", scope: "layouts.decidim"),
+                  resource_path,
+                  class: "card__button button button--sc small light secondary" %>
+    <% else %>
+      <%= link_to t("initiatives.initiative.check_and_support", scope: "layouts.decidim"),
+                  resource_path,
+                  class: "card__button button button--sc small light secondary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/models/concerns/decidim/initiative_override.rb
+++ b/app/models/concerns/decidim/initiative_override.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Decidim
+  module InitiativeOverride
+    extend ActiveSupport::Concern
+
+    included do
+      OLD_INITIATIVES = [1, 7, 8].freeze
+      OLD_SCOPE_ID = 1
+      OLD_SIGNATURES = 15_000
+
+      def supports_required
+        return OLD_SIGNATURES if OLD_INITIATIVES.include?(id)
+
+        scoped_type.supports_required
+      end
+
+      def supports_required_for(scope)
+        scoped_type = initiative_type_scopes.find_by(decidim_scopes_id: scope&.id)
+        return OLD_SIGNATURES if OLD_INITIATIVES.include?(id) && scoped_type&.id == OLD_SCOPE_ID
+
+        scoped_type.supports_required
+      end
+    end
+  end
+end

--- a/app/views/decidim/initiatives/initiatives/_progress_bar.html.erb
+++ b/app/views/decidim/initiatives/initiatives/_progress_bar.html.erb
@@ -1,0 +1,24 @@
+<div id="initiative-<%= current_initiative.id %>-progress-bar">
+  <% current_initiative.votable_initiative_type_scopes.each_with_index do |type_scope, index| %>
+    <% if index == 0 %>
+      <%= cell(
+            "decidim/progress_bar",
+            current_initiative.supports_count_for(type_scope.scope),
+            total: current_initiative.supports_required_for(type_scope.scope),
+            units_name: "decidim.initiatives.initiatives.votes_count.count",
+            element_id: "initiative-#{current_initiative.id}-votes-count",
+            subtitle_text: current_initiative.supports_goal_reached? ? t("decidim.initiatives.initiatives.votes_count.most_popular_initiative") : t("decidim.initiatives.initiatives.votes_count.need_more_votes"),
+            small: false
+          ) %>
+    <% else %>
+      <%= cell(
+            "decidim/progress_bar",
+            current_initiative.supports_count_for(type_scope.scope),
+            total: current_initiative.supports_required_for(type_scope.scope),
+            subtitle_text: translated_attribute(type_scope.scope_name),
+            element_id: "initiative-scope-#{type_scope.id}-#{current_initiative.id}-votes-count",
+            horizontal: true
+          ) %>
+    <% end %>
+  <% end %>
+</div>

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -2,6 +2,7 @@
 
 Rails.application.config.to_prepare do
   Decidim::Initiatives::InitiativeMCell.prepend Decidim::Overrides::Initiatives::InitiativeMCell
+  Decidim::Initiative.include(Decidim::InitiativeOverride)
   Decidim::Accountability::Result.include(Decidim::Accountability::ResultOverride)
   Decidim::Accountability::ResultsCalculator.include(Decidim::Accountability::ResultsCalculatorOverride)
   Decidim::Meetings::Meeting.include(Decidim::Meetings::MeetingOverride)

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -68,7 +68,10 @@ checksums = [
     package: "decidim-initiatives",
     files: {
       "/app/cells/decidim/initiatives/initiative_m_cell.rb" => "a20b707d0533dd8883b0bdbf8bc0b2c0",
+      "/app/cells/decidim/initiatives/initiative_m/footer.erb" => "3f4017aa1dd1cb30b26843ab92b32031",
+      "/app/models/decidim/initiative.rb" => "8f044f78c387b2da69280bc0c3b62179",
       "/app/views/layouts/decidim/_initiative_header_steps.html.erb" => "f1bcd3e7c406a2263d49d0f341930bfc",
+      "/app/views/decidim/initiatives/initiatives/_progress_bar.html.erb" => "ecb8b4c7e417c3dc979e7f64c19f96a5",
       "/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb" => "2c3068724ed2986f62bd13994960f39e"
     }
   },


### PR DESCRIPTION
#### :tophat: What? Why?
The number of signatures for the scoped type has changed, but it shouldn't affect to older initiatives with this scope. That's why we change these methods here for the old initiatives with this scope created when the number of signatures required was different.

We changed the views too as they called directly to the `Decidim::InitiativesTypeScope` where there is no `Decidim::Initiative` in the context.

### :camera: Screenshots (optional)
![Screenshot 2023-06-02 at 15 05 04](https://github.com/AjuntamentdeBarcelona/decidim-barcelona/assets/6973564/05a20cfb-1dab-4ed3-8b26-a286357a999a)

