### PR TITLE
Meeting buttons translation scope

### DIFF
--- a/app/cells/concerns/decidim/meetings/join_meeting_button_cell_override.rb
+++ b/app/cells/concerns/decidim/meetings/join_meeting_button_cell_override.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    module JoinMeetingButtonCellOverride
+      extend ActiveSupport::Concern
+
+      included do
+        def i18n_join_text
+          return I18n.t("register", scope: "decidim.meetings.meetings.show") if model.has_available_slots?
+
+          I18n.t("no_slots_available", scope: "decidim.meetings.meetings.show")
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -9,6 +9,7 @@ Rails.application.config.to_prepare do
   Decidim::Meetings::MeetingsController.include(Decidim::Meetings::MeetingsControllerOverride)
   Decidim::Meetings::OnlineMeetingCell.include(Decidim::Meetings::OnlineMeetingCellOverride)
   Decidim::Meetings::MeetingsHelper.include(Decidim::Meetings::MeetingsHelperOverride)
+  Decidim::Meetings::JoinMeetingButtonCell.include(Decidim::Meetings::JoinMeetingButtonCellOverride)
   Decidim::ContentBlocks::LastActivityCell.include(Decidim::ContentBlocks::LastActivityCellOverride)
   Decidim::ActivitiesCell.include(Decidim::ActivitiesCellOverride)
 end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -185,6 +185,10 @@ ca:
       initiative_signatures:
         fill_personal_data:
           document_hint: '* El número de document correspon al document utilizat en la verificació amb el padró (DNI, Passport o NIE).'
+    meetings:
+      meetings:
+        show:
+          register: Registrar-se a la trobada
     resource_links:
       included_proposals:
         project_proposals: 'Propostes incloses en aquest projecte:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,10 @@ en:
         nie: NIE
         passport: Passport
       explanation: Get verified with the census
+    meetings:
+      meetings:
+        show:
+          register: Register to the meeting
     sms:
       text: 'Your code to be verified at Decidim Barcelona is: %{code}'
   layouts:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -179,6 +179,10 @@ es:
       initiatives:
         supports:
           title: Listado de adhesiones
+    meetings:
+      meetings:
+        show:
+          register: Registrarse al encuentro
     resource_links:
       included_proposals:
         project_proposals: 'Propuestas incluidas en este proyecto:'

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -83,6 +83,7 @@ checksums = [
       "/app/cells/decidim/meetings/join_meeting_button/show.erb" => "7d85622f4dd6c7a262ab59c53a6aaedf",
       "/app/cells/decidim/meetings/online_meeting_link/show.erb" => "9557df6e46040a6395c71c75cd84792c",
       "/app/cells/decidim/meetings/online_meeting_cell.rb" => "20564c5da2200ed0c9fe42c457af26cb",
+      "/app/cells/decidim/meetings/join_meeting_button_cell.rb" => "678306ecfe31b67a1d4f13a10d189c74",
       "/app/models/decidim/meetings/meeting.rb" => "1386073a688896f7ab5b579c3080cae0",
       "/app/controllers/decidim/meetings/meetings_controller.rb" => "d0bdba675f1e3df524ac7e834e3a5f37",
       "/app/helpers/decidim/meetings/meetings_helper.rb" => "4137d363bfb0d60de112fb765102b72c",


### PR DESCRIPTION
#### :tophat: What? Why?

The URL Join meeting and the register meeting buttons were sharing the same translation.
Now they show different ones, and it can easily be overridden through Term Customizer module.

#### :pushpin: Related Issues
- Related to DECIDIM-729

### :camera: Screenshots (optional)
![image](https://github.com/AjuntamentdeBarcelona/decidim-barcelona/assets/71900287/2d0c7dfe-8607-42ac-9da3-d3892f02b0f7)