### PR TITLE
Show only one category by row

### DIFF
--- a/app/packs/stylesheets/_global_accountability.scss
+++ b/app/packs/stylesheets/_global_accountability.scss
@@ -1,11 +1,11 @@
 .global-accountability {
   .row.column {
     margin: 0 auto;
-    
+
     .page-title {
       margin-bottom: 1rem;
     }
-    
+
     .section:not(:last-child) {
       border-bottom: 1px solid rgba($medium-gray, .5);
       padding-bottom: 3rem;
@@ -20,37 +20,37 @@
     .centered--text.text-center {
       text-align: center;
     }
-    
+
     .intro--text {
       @include breakpoint(medium) {
         font-size: 1.25rem;
       }
     }
-    
+
     .card--accountability {
       text-align: left;
-      
+
       h4 {
         padding: 1.5rem 1.5rem 1rem 1.5rem;
         border-bottom: 1px solid $medium-gray;
-        
+
         .icon {
           margin-right: 0.25rem;
         }
       }
       .card__content {
         padding: 0 1.5rem 1.5rem 1.5rem;
-        
+
         ul {
           list-style: none;
           border-left: 1px solid $medium-gray;
           margin-top: 1rem;
           padding-left: 1rem;
           margin-left: 0;
-          
+
           a {
             color: $secondary;
-            
+
             &:hover,
             &:focus,
             &:active {
@@ -60,17 +60,17 @@
         }
       }
     }
-    
+
     .card--mini .card__content{
       padding: 1.5rem 0.5rem;
     }
-    
+
     .accountability--graphic {
       width: 100%;
       height: auto;
       max-width: 780px;
     }
-    
+
     .tabbed-container {
       .programme--section {
         margin-bottom: 1.5rem;
@@ -125,8 +125,12 @@
   color: inherit;
 }
 
+.accountability .categories .categories--group .card__link .category--line .category--count {
+  color: #ABA5B3;
+}
+
 .accountability .categories .categories--group .card__link .category--line strong {
-  color: white;
+  color: #182B71;
 }
 
 .accountability .categories .categories--group .category--title p.heading3 {

--- a/app/packs/stylesheets/_global_accountability.scss
+++ b/app/packs/stylesheets/_global_accountability.scss
@@ -128,3 +128,7 @@
 .accountability .categories .categories--group .card__link .category--line strong {
   color: white;
 }
+
+.accountability .categories .categories--group .category--title p.heading3 {
+  font-weight: normal;
+}

--- a/app/views/decidim/accountability/results/_home_categories.html.erb
+++ b/app/views/decidim/accountability/results/_home_categories.html.erb
@@ -26,38 +26,78 @@
   <div class="categories--list">
     <div class="row">
       <div class="small-12 columns">
-        <div class="category--section medium-12">
-          <% categories_without_children.each do |category| %>
-            <% category_results_count = count_calculator(current_scope, category) %>
-            <% next if category_results_count == 0 %>
-            <div class="categories--group row">
-              <% progress = progress_calculator(current_scope, category) %>
-              <%= link_to results_path(filter: { category_id: category, scope_id: current_scope }), class: "medium-4 columns end card__link card__link--block block--scope" do %>
-                <div class="category--title">
-                  <% if show_category_image %>
-                    <%= image_pack_tag("media/images/category-#{category.id}.jpg")  %>
-                  <% end %>
-                  <p class="heading3"><%= translated_attribute(category.name) %></p>
+        <% if categories_with_children.any? %>
+          <div class="category--section medium-12">
+            <% categories_without_children.each do |category| %>
+              <% category_results_count = count_calculator(current_scope, category) %>
+              <% next if category_results_count == 0 %>
+              <div class="categories--group row">
+                <% progress = progress_calculator(current_scope, category) %>
+                <%= link_to results_path(filter: { category_id: category, scope_id: current_scope }), class: "medium-4 columns end card__link card__link--block block--scope" do %>
+                  <div class="category--title">
+                    <% if show_category_image %>
+                      <%= image_pack_tag("media/images/category-#{category.id}.jpg")  %>
+                    <% end %>
+                    <p class="heading3"><%= translated_attribute(category.name) %></p>
 
-                  <div class="progress">
-                    <div class="progress-meter" style="width:<%= progress %>%"></div>
-                  </div>
+                    <div class="progress">
+                      <div class="progress-meter" style="width:<%= progress %>%"></div>
+                    </div>
 
-                  <% if component_settings.display_progress_enabled? && progress.present? %>
-                    <div class="progress-info">
-                      <div class="progress-figure heading3">
-                        <%= display_percentage progress %>
+                    <% if component_settings.display_progress_enabled? && progress.present? %>
+                      <div class="progress-info">
+                        <div class="progress-figure heading3">
+                          <%= display_percentage progress %>
+                        </div>
+                        <div class="category--count">
+                          <%= display_count category_results_count %>
+                        </div>
                       </div>
-                      <div class="category--count">
-                        <%= display_count category_results_count %>
+                    <% end %>
+                  </div>
+                  </div>
+                <% end %>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="categories--group row">
+            <div class="category--elements medium-12 columns">
+              <div class="row">
+                <% categories_without_children.each do |category| %>
+                  <% category_results_count = count_calculator(current_scope, category) %>
+                  <% next if category_results_count == 0 %>
+                  <% progress = progress_calculator(current_scope, category) %>
+                  <%= link_to results_path(filter: { category_id: category, scope_id: current_scope }), class: "medium-4 columns end card__link card__link--block block--scope" do %>
+                    <div class="category--scope--line <%= show_category_image ? '' : 'category--without--children' %>">
+                      <div class="scope--inner">
+                        <% if show_category_image %>
+                          <%= image_pack_tag("media/images/category-#{category.id}.jpg")  %>
+                        <% end %>
+                        <strong><%= translated_attribute(category.name) %></strong>
+
+                        <div class="progress">
+                          <div class="progress-meter" style="width:<%= progress %>%"></div>
+                        </div>
+
+                        <% if component_settings.display_progress_enabled? && progress.present? %>
+                          <div class="progress-info">
+                            <div class="progress-figure heading3">
+                              <%= display_percentage progress %>
+                            </div>
+                            <div class="category--count">
+                              <%= display_count category_results_count %>
+                            </div>
+                          </div>
+                        <% end %>
                       </div>
                     </div>
                   <% end %>
-                </div>
+                <% end %>
               </div>
-            <% end %>
-          <% end %>
-        </div>
+            </div>
+          </div>
+        <% end %>
+
         <% categories_with_children.each do |category| %>
           <% next if (category_results_count = count_calculator(current_scope, category.id)) == 0 %>
           <div class="categories--group row">

--- a/app/views/decidim/accountability/results/_home_categories.html.erb
+++ b/app/views/decidim/accountability/results/_home_categories.html.erb
@@ -26,41 +26,37 @@
   <div class="categories--list">
     <div class="row">
       <div class="small-12 columns">
-        <div class="categories--group row">
-          <div class="category--elements medium-12 columns">
-            <div class="row">
-              <% categories_without_children.each do |category| %>
-                <% category_results_count = count_calculator(current_scope, category) %>
-                <% next if category_results_count == 0 %>
-                <% progress = progress_calculator(current_scope, category) %>
-                <%= link_to results_path(filter: { category_id: category, scope_id: current_scope }), class: "medium-4 columns end card__link card__link--block block--scope" do %>
-                  <div class="category--scope--line <%= show_category_image ? '' : 'category--without--children' %>">
-                    <div class="scope--inner">
-                      <% if show_category_image %>
-                        <%= image_pack_tag("media/images/category-#{category.id}.jpg")  %>
-                      <% end %>
-                      <strong><%= translated_attribute(category.name) %></strong>
+        <div class="category--section medium-12">
+          <% categories_without_children.each do |category| %>
+            <% category_results_count = count_calculator(current_scope, category) %>
+            <% next if category_results_count == 0 %>
+            <div class="categories--group row">
+              <% progress = progress_calculator(current_scope, category) %>
+              <%= link_to results_path(filter: { category_id: category, scope_id: current_scope }), class: "medium-4 columns end card__link card__link--block block--scope" do %>
+                <div class="category--title">
+                  <% if show_category_image %>
+                    <%= image_pack_tag("media/images/category-#{category.id}.jpg")  %>
+                  <% end %>
+                  <p class="heading3"><%= translated_attribute(category.name) %></p>
 
-                      <div class="progress">
-                        <div class="progress-meter" style="width:<%= progress %>%"></div>
-                      </div>
-
-                      <% if component_settings.display_progress_enabled? && progress.present? %>
-                        <div class="progress-info">
-                          <div class="progress-figure heading3">
-                            <%= display_percentage progress %>
-                          </div>
-                          <div class="category--count">
-                            <%= display_count category_results_count %>
-                          </div>
-                        </div>
-                      <% end %>
-                    </div>
+                  <div class="progress">
+                    <div class="progress-meter" style="width:<%= progress %>%"></div>
                   </div>
-                <% end %>
-              <% end %>
-            </div>
-          </div>
+
+                  <% if component_settings.display_progress_enabled? && progress.present? %>
+                    <div class="progress-info">
+                      <div class="progress-figure heading3">
+                        <%= display_percentage progress %>
+                      </div>
+                      <div class="category--count">
+                        <%= display_count category_results_count %>
+                      </div>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
         </div>
         <% categories_with_children.each do |category| %>
           <% next if (category_results_count = count_calculator(current_scope, category.id)) == 0 %>


### PR DESCRIPTION
#### :tophat: What? Why?
Fix category style when at least one has children.

#### :pushpin: Related Issues
- Related to DECIDIM-726

#### :camera: Screenshots (optional)
All the categories have children:
![Screenshot 2023-07-11 at 15 00 25](https://github.com/AjuntamentdeBarcelona/decidim-barcelona/assets/6973564/75a24f93-f177-4c0c-8bc9-d292df3712c7)

One category has children:
![Screenshot 2023-07-11 at 14 59 28](https://github.com/AjuntamentdeBarcelona/decidim-barcelona/assets/6973564/6c1980d3-dd24-4184-b045-b0e27fe47546)

No category has children:
![Screenshot 2023-07-10 at 17 36 49](https://github.com/AjuntamentdeBarcelona/decidim-barcelona/assets/6973564/6d7046f1-4b29-46c8-ada6-fb93a608c1d9)

No category has children (customization with images):
![Screenshot 2023-07-10 at 17 36 36](https://github.com/AjuntamentdeBarcelona/decidim-barcelona/assets/6973564/dd002ab6-b104-4bfa-9c91-caf382c06410)


