### PR TITLE
Fix `ResultsCsvExporter` for results with nil weight

### DIFF
--- a/app/services/decidim/accountability/results_csv_exporter.rb
+++ b/app/services/decidim/accountability/results_csv_exporter.rb
@@ -66,7 +66,7 @@ module Decidim
           result.decidim_accountability_status_id,
           result.progress,
           result.resource_links_from.select { |link| link.to_type == "Decidim::Proposals::Proposal" }.map(&:to_id).sort.join(";"),
-          result.weight * 100.0
+          (result.weight || 0) * 100.0
         ]
         available_locales.each do |locale|
           row << result.title[locale]

--- a/spec/services/results_csv_exporter_spec.rb
+++ b/spec/services/results_csv_exporter_spec.rb
@@ -16,16 +16,27 @@ module Decidim::Accountability
     let!(:parent_result) { create :result, component: current_component, external_id: "pm-act-423" }
 
     describe "#export" do
-      it "updates them" do
+      before do
         csv_export = subject.export
 
         csv = CSV.parse(csv_export, headers: true)
 
         expect(csv.count).to eq 1
-        first_row = csv[0]
-        expect(first_row["external_id"]).to eq(parent_result.external_id)
-        expect(first_row["relative_weight"].to_f).to eq(parent_result.weight * 100.0)
-        expect(first_row["result_id"].to_i).to eq(parent_result.id)
+        @first_row = csv[0]
+      end
+
+      it "updates them" do
+        expect(@first_row["external_id"]).to eq(parent_result.external_id)
+        expect(@first_row["relative_weight"].to_f).to eq(parent_result.weight * 100.0)
+        expect(@first_row["result_id"].to_i).to eq(parent_result.id)
+      end
+
+      context "when result is nil" do
+        let!(:parent_result) { create :result, component: current_component, external_id: "pm-act-423", weight: nil }
+
+        it "exports weight as 0" do
+          expect(@first_row["relative_weight"].to_f).to eq(0.0)
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Fix error on `app/services/decidim/accountability/results_csv_exporter.rb:69`:

```
undefined method `*' for nil:NilClass
```

#### :pushpin: Related Issues
- Related to [Sentry 1b4199466b9745eab77f0752099d2186](https://decidim-barcelona-q1.sentry.io/issues/3616994705/events/1b4199466b9745eab77f0752099d2186/)
