### PR TITLE
Fix legacy routing redirections

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -61,3 +61,4 @@ exclude_paths:
 - "config/initializers/origami_date.rb"
 - "config/initializers/decidim.rb"
 - "decidim-ephemeral_participation/app/permissions/decidim/ephemeral_participation/ephemeral_participation_permissions.rb"
+- "app/services/decidim_legacy_routes.rb"

--- a/app/services/decidim_legacy_routes.rb
+++ b/app/services/decidim_legacy_routes.rb
@@ -14,17 +14,17 @@ class DecidimLegacyRoutes
     component_manifest_name = component_translation[0]
 
     component = Decidim::Component.published.find_by(
-      manifest_name: component_manifest_name,
+      manifest_name: component_manifest_name == :results ? :accountability : component_manifest_name,
       participatory_space: process
     )
 
     if params[:resource_id]
       resource_class = component_translation[1]
-      resource = resource_class.where("extra->>'slug' = ?", params[:resource_id]).first || resource_class.find(params[:resource_id])
+      resource = resource_class.find_by(id: params[:resource_id]) || resource_class.where("extra->>'slug' = ?", params[:resource_id]).first
 
-      "/processes/#{process.id}/f/#{component.id}/#{component_manifest_name}/#{resource.id}"
+      "/processes/#{process.slug}/f/#{component.id}/#{component_manifest_name}/#{resource.id}"
     else
-      "/processes/#{process.id}/f/#{component.id}"
+      "/processes/#{process.slug}/f/#{component.id}"
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,8 +32,8 @@ Rails.application.routes.draw do
                  end
       component = resource.component
       process = component.participatory_space
-      component_manifest_name = component.manifest_name
-      "/processes/#{process.id}/f/#{component.id}/#{component_manifest_name}/#{resource.id}"
+      component_manifest_name = component.manifest_name == "accountability" ? "results" : component.manifest_name
+      "/processes/#{process.slug}/f/#{component.id}/#{component_manifest_name}/#{resource.id}"
     }, constraints: { component_name: Regexp.new(component_translations.keys.join("|")), resource_id: %r{(?!meetings)[^/]*} }
   end
   # rubocop:enable Layout/LineLength

--- a/spec/routing/redirections_spec.rb
+++ b/spec/routing/redirections_spec.rb
@@ -7,6 +7,8 @@ require "decidim/assemblies/test/factories"
 require "decidim/participatory_processes/test/factories"
 require "decidim/proposals/test/factories"
 require "decidim/meetings/test/factories"
+require "decidim/debates/test/factories"
+require "decidim/accountability/test/factories"
 
 describe "routing redirections", type: :request do
   let(:organization) { create(:organization, host: "decidim.barcelona", available_authorizations: authorizations) }
@@ -15,6 +17,100 @@ describe "routing redirections", type: :request do
       "dummy_authorization_handler" => { "allow_ephemeral_participation" => true },
       "another_dummy_authorization_handler" => { "allow_ephemeral_participation" => false }
     }
+  end
+
+  describe "debates" do
+    let(:participatory_space) { create(:participatory_process, organization: organization, slug: "test-process") }
+    let(:component) { create(:debates_component, participatory_space: participatory_space) }
+    let!(:debate) { create(:debate, component: component, extra: { slug: "test-debate" }) }
+
+    context "with the right host" do
+      before do
+        host! organization.host
+      end
+
+      it "redirects top-level debates" do
+        expect(get("/debates/test-debate"))
+          .to redirect_to("/processes/#{participatory_space.slug}/f/#{component.id}/debates/#{debate.id}")
+      end
+
+      it "redirects debates inside the old structure without step ID" do
+        expect(get("/test-process/debates/test-debate"))
+          .to redirect_to("/processes/#{participatory_space.slug}/f/#{component.id}/debates/#{debate.id}")
+      end
+
+      it "redirects debates inside the old structure without step ID using debate id" do
+        expect(get("/test-process/debates/#{debate.id}"))
+          .to redirect_to("/processes/#{participatory_space.slug}/f/#{component.id}/debates/#{debate.id}")
+      end
+
+      it "redirects debates inside the old step structure" do
+        expect(get("/test-process/123/debates/test-debate"))
+          .to redirect_to("/processes/#{participatory_space.slug}/f/#{component.id}/debates/#{debate.id}")
+      end
+
+      it "redirects debates inside the old step structure using debate id" do
+        expect(get("/test-process/123/debates/#{debate.id}"))
+          .to redirect_to("/processes/#{participatory_space.slug}/f/#{component.id}/debates/#{debate.id}")
+      end
+
+      it "redirects index paths inside the old step structure" do
+        expect(get("/test-process/123/debates/"))
+          .to redirect_to("/processes/#{participatory_space.slug}/f/#{component.id}")
+      end
+    end
+
+    context "with the wrong host" do
+      before do
+        host! "foo.bar"
+      end
+
+      it "doesn't redirect" do
+        expect { get("/debates/test-debate") }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+
+  describe "accountability" do
+    let(:participatory_space) { create(:participatory_process, organization: organization, slug: "test-process") }
+    let(:component) { create(:accountability_component, participatory_space: participatory_space) }
+    let!(:result) { create(:result, component: component) }
+
+    context "with the right host" do
+      before do
+        host! organization.host
+      end
+
+      it "redirects top-level accountability result" do
+        expect(get("/action_plans/#{result.id}"))
+          .to redirect_to("/processes/#{participatory_space.slug}/f/#{component.id}/results/#{result.id}")
+      end
+
+      it "redirects accountability results inside the old structure without step ID" do
+        expect(get("/test-process/action_plans/#{result.id}"))
+          .to redirect_to("/processes/#{participatory_space.slug}/f/#{component.id}/results/#{result.id}")
+      end
+
+      it "redirects accountability results inside the old step structure" do
+        expect(get("/test-process/123/action_plans/#{result.id}"))
+          .to redirect_to("/processes/#{participatory_space.slug}/f/#{component.id}/results/#{result.id}")
+      end
+
+      it "redirects index paths inside the old step structure" do
+        expect(get("/test-process/123/action_plans/"))
+          .to redirect_to("/processes/#{participatory_space.slug}/f/#{component.id}")
+      end
+    end
+
+    context "with the wrong host" do
+      before do
+        host! "foo.bar"
+      end
+
+      it "doesn't redirect" do
+        expect { get("/action_plans/test-result") }.to raise_error(ActionController::RoutingError)
+      end
+    end
   end
 
   describe "proposals" do
@@ -29,22 +125,22 @@ describe "routing redirections", type: :request do
 
       it "redirects top-level proposals" do
         expect(get("/proposals/test-proposal"))
-          .to redirect_to("/processes/#{participatory_process.id}/f/#{component.id}/proposals/#{proposal.id}")
+          .to redirect_to("/processes/#{participatory_process.slug}/f/#{component.id}/proposals/#{proposal.id}")
       end
 
       it "redirects proposals inside the old structure without step ID" do
         expect(get("/test-process/proposals/test-proposal"))
-          .to redirect_to("/processes/#{participatory_process.id}/f/#{component.id}/proposals/#{proposal.id}")
+          .to redirect_to("/processes/#{participatory_process.slug}/f/#{component.id}/proposals/#{proposal.id}")
       end
 
       it "redirects proposals inside the old step structure" do
         expect(get("/test-process/123/proposals/test-proposal"))
-          .to redirect_to("/processes/#{participatory_process.id}/f/#{component.id}/proposals/#{proposal.id}")
+          .to redirect_to("/processes/#{participatory_process.slug}/f/#{component.id}/proposals/#{proposal.id}")
       end
 
       it "redirects index paths inside the old step structure" do
         expect(get("/test-process/123/proposals/"))
-          .to redirect_to("/processes/#{participatory_process.id}/f/#{component.id}")
+          .to redirect_to("/processes/#{participatory_process.slug}/f/#{component.id}")
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The legacy routes redirections weren't updated and they were failing for accountability result components.

#### :pushpin: Related Issues
- Related to [Sentry 10558c3944d04140880ca168c31a21af](https://decidim-barcelona-q1.sentry.io/issues/1727072047/events/10558c3944d04140880ca168c31a21af/)
