### PR TITLE
Avoid exception accessing a space with dataviz component

### DIFF
--- a/decidim-dataviz/lib/decidim/dataviz.rb
+++ b/decidim-dataviz/lib/decidim/dataviz.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/dataviz/admin"
+require "decidim/dataviz/admin_engine"
 require "decidim/dataviz/engine"
 require "decidim/dataviz/component"
 

--- a/decidim-dataviz/lib/decidim/dataviz/admin.rb
+++ b/decidim-dataviz/lib/decidim/dataviz/admin.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Dataviz
+    # This module contains all the domain logic associated to the decidim-dataviz
+    # module admin panel.
+    module Admin
+    end
+  end
+end

--- a/decidim-dataviz/lib/decidim/dataviz/admin_engine.rb
+++ b/decidim-dataviz/lib/decidim/dataviz/admin_engine.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Dataviz
+    # This is the engine that runs on the admin interface of decidim-dataviz.
+    class AdminEngine < ::Rails::Engine
+      isolate_namespace Decidim::Dataviz::Admin
+
+      paths["db/migrate"] = nil
+      paths["lib/tasks"] = nil
+
+      def load_seed
+        nil
+      end
+    end
+  end
+end

--- a/decidim-dataviz/lib/decidim/dataviz/component.rb
+++ b/decidim-dataviz/lib/decidim/dataviz/component.rb
@@ -4,5 +4,6 @@ require_dependency "decidim/components/namer"
 
 Decidim.register_component(:dataviz) do |component|
   component.engine = Decidim::Dataviz::Engine
+  component.admin_engine = Decidim::Pages::AdminEngine
   component.icon = "media/images/decidim/dataviz/icon.svg"
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Couldn't access the admin page of a space with a dataviz component

#### :pushpin: Related Issues
- Related to [Sentry 475d64aa71ff410a9b441911f52c3687](https://decidim-barcelona-q1.sentry.io/issues/4382928681/events/475d64aa71ff410a9b441911f52c3687/)
