### PR TITLE
Limit number of days in the metrics page

### DIFF
--- a/app/resolvers/decidim/core/metric_resolver_override.rb
+++ b/app/resolvers/decidim/core/metric_resolver_override.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    module MetricResolverOverride
+      extend ActiveSupport::Concern
+
+      private
+
+      included do
+        def sum
+          @records = @records.limit(30).sum(counter_field)
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -13,4 +13,5 @@ Rails.application.config.to_prepare do
   Decidim::Meetings::JoinMeetingButtonCell.include(Decidim::Meetings::JoinMeetingButtonCellOverride)
   Decidim::ContentBlocks::LastActivityCell.include(Decidim::ContentBlocks::LastActivityCellOverride)
   Decidim::ActivitiesCell.include(Decidim::ActivitiesCellOverride)
+  Decidim::Core::MetricResolver.include(Decidim::Core::MetricResolverOverride)
 end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -21,7 +21,8 @@ checksums = [
       "/app/views/layouts/decidim/_user_menu.html.erb" => "de17337bd45f6e6d5aa455267f70430f", # ephemeral participation overrides
       "/app/views/layouts/decidim/widget.html.erb" => "b9fb503118ee33d298cbc585995e216c",
       "/app/cells/decidim/content_blocks/last_activity_cell.rb" => "2ddcb8ba5070f7cdb231283185f2c213",
-      "/app/cells/decidim/activities_cell.rb" => "af9e9e2b6e4134fa90b6699bbf7da428"
+      "/app/cells/decidim/activities_cell.rb" => "af9e9e2b6e4134fa90b6699bbf7da428",
+      "/app/resolvers/decidim/core/metric_resolver.rb" => "2bbfb7ebecbe025183f00cd3b148137b"
     }
   },
   {


### PR DESCRIPTION
#### :tophat: What? Why?
Limit the number of days shown in the limit page to successfully load the page.

#### :pushpin: Related Issues
- Fixes #487
