### PR TITLE
Fix filter results

### DIFF
--- a/app/views/decidim/accountability/results/_home_categories.html.erb
+++ b/app/views/decidim/accountability/results/_home_categories.html.erb
@@ -33,7 +33,7 @@
               <% next if category_results_count == 0 %>
               <div class="categories--group row">
                 <% progress = progress_calculator(current_scope, category) %>
-                <%= link_to results_path(filter: { category_id: category, scope_id: current_scope }), class: "medium-4 columns end card__link card__link--block block--scope" do %>
+                <%= link_to results_path(filter: { with_category: category, with_scope: current_scope }), class: "medium-4 columns end card__link card__link--block block--scope" do %>
                   <div class="category--title">
                     <% if show_category_image %>
                       <%= image_pack_tag("media/images/category-#{category.id}.jpg")  %>
@@ -67,7 +67,7 @@
                   <% category_results_count = count_calculator(current_scope, category) %>
                   <% next if category_results_count == 0 %>
                   <% progress = progress_calculator(current_scope, category) %>
-                  <%= link_to results_path(filter: { category_id: category, scope_id: current_scope }), class: "medium-4 columns end card__link card__link--block block--scope" do %>
+                  <%= link_to results_path(filter: { with_category: category, with_scope: current_scope }), class: "medium-4 columns end card__link card__link--block block--scope" do %>
                     <div class="category--scope--line <%= show_category_image ? '' : 'category--without--children' %>">
                       <div class="scope--inner">
                         <% if show_category_image %>
@@ -104,7 +104,7 @@
             <div class="category--section small-12 medium-4 columns">
               <div class="category--title">
                 <p class="heading3">
-                <%= link_to translated_attribute(category.name),results_path(filter: { category_id: category, scope_id: current_scope }) %></p>
+                <%= link_to translated_attribute(category.name),results_path(filter: { with_category: category, with_scope: current_scope }) %></p>
 
                 <% if component_settings.display_progress_enabled? && progress_calculator(current_scope, category.id).present? %>
                   <div class="progress">
@@ -129,7 +129,7 @@
               <div class="row">
                 <% category.subcategories.each do |subcategory| %>
                   <% if (subcategory_results_count = count_calculator(current_scope, subcategory.id)) > 0 %>
-                    <%= link_to results_path(filter: { category_id: subcategory, scope_id: current_scope }), class: "medium-4 columns end card__link card__link--block" do %>
+                    <%= link_to results_path(filter: { with_category: subcategory, with_scope: current_scope }), class: "medium-4 columns end card__link card__link--block" do %>
                       <div class="category--line">
                         <strong><%= translated_attribute(subcategory.name) %></strong>
 


### PR DESCRIPTION
#### :tophat: What? Why?
After the [migration to `ransack`](https://github.com/decidim/decidim/pull/8748) applied in the 0.27 verstion, a bug appeared in the custom view for home categories in the accountability component as the URL generated to access the results of each category needed a change in the key for the category and scope filters.

#### :pushpin: Related Issues
- Fixes DECIDIM-757
