### PR TITLE
Send publish component notification even when the component is (re)published

### DIFF
--- a/app/commands/decidim/admin/publish_component.rb
+++ b/app/commands/decidim/admin/publish_component.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # This command gets called when a component is published from the admin panel.
+    class PublishComponent < Decidim::Command
+      # Public: Initializes the command.
+      #
+      # component - The component to publish.
+      # current_user - the user performing the action
+      def initialize(component, current_user)
+        @component = component
+        @current_user = current_user
+      end
+
+      # Public: Publishes the Component.
+      #
+      # Broadcasts :ok if published, :invalid otherwise.
+      def call
+        publish_component
+        publish_event
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :component, :current_user
+
+      def publish_component
+        Decidim.traceability.perform_action!(
+          :publish,
+          component,
+          current_user,
+          visibility: "all"
+        ) do
+          component.publish!
+          component
+        end
+      end
+
+      def publish_event
+        Decidim::EventsManager.publish(
+          event: "decidim.events.components.component_published",
+          event_class: Decidim::ComponentPublishedEvent,
+          resource: component,
+          followers: component.participatory_space.followers
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -27,6 +27,7 @@ checksums = [
   {
     package: "decidim-admin",
     files: {
+      "/app/commands/decidim/admin/publish_component.rb" => "48b73691b2aea10191ed427702a74359", # revert https://github.com/decidim/decidim/pull/10690
       "/app/commands/decidim/admin/transfer_user.rb" => "7cf11abc98c3a0c4a656ab96c220dd6a", # ephemeral participation overrides
       "/app/controllers/decidim/admin/conflicts_controller.rb" => "dfe4daf8dcb7b4963e37651b0fe8df3c", # ephemeral participation overrides
       "/app/forms/decidim/admin/component_form.rb" => "0455dd26580817470fd7096ef6b08315", # ephemeral participation overrides


### PR DESCRIPTION
#### :tophat: What? Why?
Revert [this change](https://github.com/decidim/decidim/pull/10690/files#diff-e2b21b3919dab12185ee7a8e2d0f97b5c5a5666b5bc7ae9baba233b12ebdfaa9) as we want the answers of the component to be cleared when it's (re)published.

#### :pushpin: Related Issues
- Fixes DECIDIM-754
- Fixes #496
