### PR TITLE
Fix error rendering proposals with a linked proposal with deleted author

### DIFF
--- a/app/presenters/concerns/decidim/deleted_author_presenter.rb
+++ b/app/presenters/concerns/decidim/deleted_author_presenter.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Decidim
+  #
+  # A dummy presenter to abstract out a deleted author.
+  #
+  class DeletedAuthorPresenter < Decidim::OfficialAuthorPresenter
+    def name
+      I18n.t("decidim.profile.deleted")
+    end
+  end
+end

--- a/app/presenters/concerns/decidim/proposals/proposal_presenter_override.rb
+++ b/app/presenters/concerns/decidim/proposals/proposal_presenter_override.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module ProposalPresenterOverride
+      extend ActiveSupport::Concern
+
+      included do
+        def author
+          @author ||= if official?
+                        Decidim::Proposals::OfficialAuthorPresenter.new
+                      else
+                        coauthorship = coauthorships.includes(:author, :user_group).first
+                        return coauthorship.user_group.presenter if coauthorship&.user_group
+                        return coauthorship.author.presenter if coauthorship&.author
+
+                        Decidim::DeletedAuthorPresenter.new
+                      end
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -14,4 +14,5 @@ Rails.application.config.to_prepare do
   Decidim::ContentBlocks::LastActivityCell.include(Decidim::ContentBlocks::LastActivityCellOverride)
   Decidim::ActivitiesCell.include(Decidim::ActivitiesCellOverride)
   Decidim::UserProfileCell.include(Decidim::UserProfileCellOverride)
+  Decidim::Proposals::ProposalPresenter.include(Decidim::Proposals::ProposalPresenterOverride)
 end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -94,6 +94,12 @@ checksums = [
     }
   },
   {
+    package: "decidim-proposals",
+    files: {
+      "/app/presenters/decidim/proposals/proposal_presenter.rb" => "105b7266bcdd8b947ababbb7ebb78789"
+    }
+  },
+  {
     # Fix origami date compatibility with Ruby 3.0 monkey-patching it on origami_date.rb
     package: "origami",
     files: {


### PR DESCRIPTION
#### :tophat: What? Why?
Show "deleted user" when the linked proposal author has been deleted avoiding raising the error described in the below-mentioned issue.

#### :pushpin: Related Issues
- Fixes #509

### :camera: Screenshots (optional)
![Screenshot 2023-11-13 at 13 31 36](https://github.com/AjuntamentdeBarcelona/decidim-barcelona/assets/6973564/0c3a7bdf-370e-440f-a022-88683c1867cf)

