### PR TITLE
Update email stylesheets and add it to the overrides spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,6 @@ Citizen Participation and Open Government Application.
 
 This is the opensource code repository for "decidim-barcelona", based on [Decidim](https://github.com/AjuntamentdeBarcelona/decidim).
 
-## Upgrade notes
-
-- `app/views/layouts/decidim/widget.html.erb` modify the embed to remove organization's logo.
-- `app/stylesheets/decidim/email.css`, customizes the email template style of Decidim. Be careful in later updates to prevent changes in style.
-
 ## Development environment setup
 
 You can setup everything with Docker & Docker compose, run:

--- a/app/packs/stylesheets/email.scss
+++ b/app/packs/stylesheets/email.scss
@@ -25,6 +25,13 @@ body{
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
+
+  &.preview{
+    .see-on-website,
+    .unsubscribe{
+      cursor: not-allowed;
+    }
+  }
 }
 
 .ExternalClass{
@@ -1780,4 +1787,70 @@ table.content.image img{
 th,
 td{
   box-sizing: border-box;
+}
+
+.email-notifications-digest{
+  .email-header{
+    margin-bottom: 32px;
+    font-size: 16px;
+    font-weight: bold;
+    color: #2c2930;
+    display: inline-block;
+    width: 49%;
+
+    &--right{
+      text-align: right;
+    }
+  }
+
+  .email-intro{
+    font-size: 16px;
+    line-height: 21px;
+  }
+
+  .email-content-notifications{
+    background-color: #f4f4f4;
+    border-radius: 5px;
+    border: 1px #e5e5e5;
+    padding: 16px;
+    margin: 32px 0;
+  }
+
+  .email-content-notification{
+    p a{
+      color: #327f9b;
+      font-weight: bold;
+      text-decoration: underline;
+    }
+  }
+
+  .email-element-separator{
+    margin: 24px 0;
+    color: #e5e5e5;
+    border-color: #e5e5e5;
+    height: 0;
+    border-style: solid;
+    border-width: 1px;
+  }
+
+  .email-notification-date{
+    color: #666d7a;
+    display: block;
+    margin-bottom: 10px;
+  }
+
+  .email-closing{
+    font-size: 14px;
+  }
+
+  .email-btn{
+    border: solid 1px;
+    margin: 0 33% 30px;
+    width: 33%;
+    text-align: center;
+    display: inline-block;
+    padding: 10px;
+    color: #5295ad;
+    text-decoration: none;
+  }
 }

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -15,6 +15,7 @@ checksums = [
       "/app/models/decidim/organization.rb" => "e3d474ed92c0b8bb8911e6947a569845", # ephemeral participation overrides
       "/app/models/decidim/permission_action.rb" => "00da630bf229dc8d482dc0e0b2d6a95c", # ephemeral participation overrides
       "/app/models/decidim/user.rb" => "cf6431b9ac57510d189df46ca3da9a04", # ephemeral participation overrides
+      "/app/packs/stylesheets/decidim/email.scss" => "7e6a7b5d0327696b8a9d481fdb8d8d70",
       "/app/permissions/decidim/permissions.rb" => "ace85e448814ed71bbea5e7515b95d5d", # ephemeral participation overrides
       "/app/views/decidim/shared/_login_modal.html.erb" => "bf583a391dc1cc50fc8261dd850dfcc1", # ephemeral participation overrides
       "/app/views/layouts/decidim/mailer.html.erb" => "0c7804de08649c8d3c55c117005e51c9",


### PR DESCRIPTION
#### :tophat: What? Why?
The `email.scss` wasn't in the `spec/lib/overrides_spec.rb` and it was indicated in the README.md that it has some monkey patch applied. In this PR I move this file to the overrides spec and include the missing commits coming from: https://github.com/decidim/decidim/pull/8833 and https://github.com/decidim/decidim/pull/9635