### PR TITLE
New comments cleaner task to remove comments with nil reference

### DIFF
--- a/app/lib/decidim/overrides/search_resource_fields_mapper.rb
+++ b/app/lib/decidim/overrides/search_resource_fields_mapper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Overrides
+    module SearchResourceFieldsMapper
+      # Override this method to avoid an error trying to remove a comment with a nil commentable
+      # as it tries to get the organization of a nil organization
+      def retrieve_organization(resource)
+        if @declared_fields[:organization_id].present?
+          organization_id = read_field(resource, @declared_fields, :organization_id)
+          Decidim::Organization.find_by(id: organization_id)
+        else
+          participatory_space(resource)&.organization || Decidim::Organization.first
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -3,6 +3,7 @@
 Rails.application.config.to_prepare do
   Decidim::Initiatives::Admin::Permissions.prepend(Decidim::Initiatives::Admin::PermissionsOverride)
   Decidim::Initiatives::InitiativeMCell.prepend Decidim::Overrides::Initiatives::InitiativeMCell
+  Decidim::SearchResourceFieldsMapper.prepend Decidim::Overrides::SearchResourceFieldsMapper
   Decidim::Initiative.include(Decidim::InitiativeOverride)
   Decidim::Accountability::Result.include(Decidim::Accountability::ResultOverride)
   Decidim::Accountability::ResultsCalculator.include(Decidim::Accountability::ResultsCalculatorOverride)

--- a/lib/tasks/comments_cleaner.rake
+++ b/lib/tasks/comments_cleaner.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :comments_cleaner do
+  desc "Destroy comments with nil commentable or author"
+  task clean: :environment do
+    log = ActiveSupport::Logger.new(Rails.root.join("log/comments_cleaner-clean.log"))
+    Decidim::Comments::Comment.all.select { |comment| comment.commentable.nil? || comment.author.nil? }.each do |comment|
+      p "Comment ##{comment.id} successfully destroyed" if comment.destroy
+    rescue StandardError => e
+      log.error "Error removing comment ##{comment.id}: #{e.message}"
+    end
+  end
+end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -22,7 +22,8 @@ checksums = [
       "/app/views/layouts/decidim/widget.html.erb" => "b9fb503118ee33d298cbc585995e216c",
       "/app/cells/decidim/content_blocks/last_activity_cell.rb" => "2ddcb8ba5070f7cdb231283185f2c213",
       "/app/cells/decidim/activities_cell.rb" => "af9e9e2b6e4134fa90b6699bbf7da428",
-      "/app/cells/decidim/user_profile_cell.rb" => "30627556740555814f5cf279491aee94"
+      "/app/cells/decidim/user_profile_cell.rb" => "30627556740555814f5cf279491aee94",
+      "/lib/decidim/search_resource_fields_mapper.rb" => "ff2cc476eb72c2942cf2e69ae21b84fa"
     }
   },
   {


### PR DESCRIPTION
#### :tophat: What? Why?

Add a new task to destroy comments with nil commentable or author. You only need to run:

```bash
bin/rails comments_cleaner:clean
```

#### :pushpin: Related Issues

- Fixes #515