### PR TITLE
Allow users to include videos in the proposals

### DIFF
--- a/app/helpers/concerns/decidim/proposals/application_helper_override.rb
+++ b/app/helpers/concerns/decidim/proposals/application_helper_override.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module ApplicationHelperOverride
+      extend ActiveSupport::Concern
+
+      included do
+        def safe_content_admin?
+          ((@proposal.official? || @proposal.official_meeting?) && not_from_participatory_text(@proposal)) || safe_content_allowed_user?
+        end
+
+        private
+
+        def safe_content_allowed_user?
+          @proposal.authored_by?(safe_content_allowed_users)
+        end
+
+        def safe_content_allowed_users
+          @safe_content_allowed_users ||= Decidim::User.where(id: ENV.fetch("PROPOSAL_SAFE_CONTENT_ALLOWED_USERS", "").split(","))
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/concerns/decidim/proposals/application_helper_override.rb
+++ b/app/helpers/concerns/decidim/proposals/application_helper_override.rb
@@ -6,6 +6,7 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
+        # rubocop:disable Rails/HelperInstanceVariable
         def safe_content_admin?
           ((@proposal.official? || @proposal.official_meeting?) && not_from_participatory_text(@proposal)) || safe_content_allowed_user?
         end
@@ -19,6 +20,7 @@ module Decidim
         def safe_content_allowed_users
           @safe_content_allowed_users ||= Decidim::User.where(id: ENV.fetch("PROPOSAL_SAFE_CONTENT_ALLOWED_USERS", "").split(","))
         end
+        # rubocop:enable Rails/HelperInstanceVariable
       end
     end
   end

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -17,4 +17,5 @@ Rails.application.config.to_prepare do
   Decidim::UserProfileCell.include(Decidim::UserProfileCellOverride)
   Decidim::Proposals::ProposalPresenter.include(Decidim::Proposals::ProposalPresenterOverride)
   Decidim::Forms::QuestionnaireUserAnswers.include(Decidim::Forms::QuestionnaireUserAnswersOverride)
+  Decidim::Proposals::ApplicationHelper.include(Decidim::Proposals::ApplicationHelperOverride)
 end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -98,6 +98,7 @@ checksums = [
   {
     package: "decidim-proposals",
     files: {
+      "/app/helpers/decidim/proposals/application_helper.rb" => "a9c9ed5eedaf7bf80afaf9ff5a89c254",
       "/app/presenters/decidim/proposals/proposal_presenter.rb" => "105b7266bcdd8b947ababbb7ebb78789"
     }
   },

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,6 +38,7 @@ Decidim::CapybaraTestHelpers.prepend(CapybaraTestHelpersPatch)
 require "decidim/ephemeral_participation/test"
 require "decidim/census_sms/verification/test"
 require "decidim/budgets/test/factories"
+require "decidim/proposals/test/factories"
 require "decidim/surveys/test/factories"
 require "decidim/system/test/factories"
 

--- a/spec/system/proposal_safe_content_allowed_users_spec.rb
+++ b/spec/system/proposal_safe_content_allowed_users_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Proposal safe content allowed users", type: :system, perform_enqueued: true do
+  include_context "with a component"
+  let(:manifest_name) { "proposals" }
+
+  let!(:proposal) { create(:proposal, :participant_author, skip_injection: true, component: component, body: { "en" => body }) }
+  let(:proposal_title) { translated(proposal.title) }
+  let(:body) do
+    <<~HTML.strip
+      <p><img src="/path/to/image.jpg" alt="Image"></p>
+      <div class="editor-content-videoEmbed">
+        <div>
+          <iframe src="https://example.org/video/xyz" title="Video" frameborder="0" allowfullscreen="true"></iframe>
+        </div>
+      </div>
+    HTML
+  end
+  let(:allowed_users) { "" }
+
+  let(:organization) { create(:organization) }
+
+  before do
+    ENV["PROPOSAL_SAFE_CONTENT_ALLOWED_USERS"] = allowed_users
+    data_consent(true, visit_root: true)
+    visit_component
+    click_link proposal_title
+  end
+
+  context "without allowed user" do
+    it "doesn't render the image neither the iframe embed" do
+      expect(page).not_to have_css(".ql-editor-display img[src='/path/to/image.jpg']")
+      expect(page).not_to have_css(".editor-content-videoEmbed .disabled-iframe")
+    end
+  end
+
+  context "with allowed user" do
+    let(:allowed_users) { proposal.authors.first.id.to_s }
+
+    it "renders the image and iframe embed" do
+      expect(page).to have_css(".ql-editor-display img[src='/path/to/image.jpg']")
+      expect(page).to have_css(".editor-content-videoEmbed iframe[src='https://example.org/video/xyz']")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Allow users to use videos in the proposals if they are present in the `PROPOSAL_SAFE_CONTENT_ALLOWED_USERS` environment variable.

#### :pushpin: Related Issues
- Fixes #537
