### PR TITLE
Fix column order exporting survey answers on CSV

### DIFF
--- a/app/lib/decidim/overrides/forms/user_answers_serializer.rb
+++ b/app/lib/decidim/overrides/forms/user_answers_serializer.rb
@@ -4,7 +4,6 @@ module Decidim
   module Overrides
     module Forms
       module UserAnswersSerializer
-
         private
 
         def hash_for(answer)

--- a/app/lib/decidim/overrides/forms/user_answers_serializer.rb
+++ b/app/lib/decidim/overrides/forms/user_answers_serializer.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Overrides
+    module Forms
+      module UserAnswersSerializer
+
+        private
+
+        def hash_for(answer)
+          {
+            answer_translated_attribute_name(:id) => answer&.session_token,
+            answer_translated_attribute_name(:user_status) => answer_translated_attribute_name(answer&.decidim_user_id.present? ? "registered" : "unregistered"),
+            answer_translated_attribute_name(:ip_hash) => answer&.ip_hash,
+            answer_translated_attribute_name(:created_at) => answer&.created_at
+          }
+        end
+
+        def questions_hash
+          questionnaire_id = @answers.first&.decidim_questionnaire_id
+          return {} unless questionnaire_id
+
+          questions = Decidim::Forms::Question.where(decidim_questionnaire_id: questionnaire_id).order(:position)
+          return {} if questions.none?
+
+          questions.each.inject({}) do |serialized, question|
+            serialized.update(
+              translated_question_key(question.position, question.body) => ""
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -4,6 +4,7 @@ Rails.application.config.to_prepare do
   Decidim::Initiatives::Admin::Permissions.prepend(Decidim::Initiatives::Admin::PermissionsOverride)
   Decidim::Initiatives::InitiativeMCell.prepend Decidim::Overrides::Initiatives::InitiativeMCell
   Decidim::SearchResourceFieldsMapper.prepend Decidim::Overrides::SearchResourceFieldsMapper
+  Decidim::Forms::UserAnswersSerializer.prepend Decidim::Overrides::Forms::UserAnswersSerializer
   Decidim::Initiative.include(Decidim::InitiativeOverride)
   Decidim::Accountability::Result.include(Decidim::Accountability::ResultOverride)
   Decidim::Accountability::ResultsCalculator.include(Decidim::Accountability::ResultsCalculatorOverride)

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -106,7 +106,8 @@ checksums = [
     package: "decidim-forms",
     files: {
       "/app/queries/decidim/forms/questionnaire_user_answers.rb" => "fb14ed5f570c6d18e5d0d83808d03b5d",
-      "/app/views/decidim/forms/admin/questionnaires/answers/show.html.erb" => "49e39b6688f3109b87ec74890bc566fb"
+      "/app/views/decidim/forms/admin/questionnaires/answers/show.html.erb" => "49e39b6688f3109b87ec74890bc566fb",
+      "/lib/decidim/forms/user_answers_serializer.rb" => "a81a7e01a12ead59cc6cb7505b1041b5"
     }
   },
   {


### PR DESCRIPTION
#### :tophat: What? Why?
Fix the order of the column to be the same as the one shown in the admin page (order questions by position)

#### :pushpin: Related Issues
- Related to #522 
- Fixes #535 
