### PR TITLE
Do not show deleted users on verification conflicts list

### DIFF
--- a/app/controllers/concerns/decidim/admin/conflicts_controller_override.rb
+++ b/app/controllers/concerns/decidim/admin/conflicts_controller_override.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    module ConflictsControllerOverride
+      extend ActiveSupport::Concern
+
+      included do
+        def index
+          enforce_permission_to :index, :impersonatable_user
+
+          @conflicts = Decidim::Verifications::Conflict.joins(:current_user).where(
+            decidim_users: { decidim_organization_id: current_organization.id, deleted_at: nil }
+          )
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -19,4 +19,5 @@ Rails.application.config.to_prepare do
   Decidim::Proposals::ProposalPresenter.include(Decidim::Proposals::ProposalPresenterOverride)
   Decidim::Forms::QuestionnaireUserAnswers.include(Decidim::Forms::QuestionnaireUserAnswersOverride)
   Decidim::Proposals::ApplicationHelper.include(Decidim::Proposals::ApplicationHelperOverride)
+  Decidim::Admin::ConflictsController.include(Decidim::Admin::ConflictsControllerOverride)
 end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -32,7 +32,7 @@ checksums = [
     files: {
       "/app/commands/decidim/admin/publish_component.rb" => "48b73691b2aea10191ed427702a74359", # revert https://github.com/decidim/decidim/pull/10690
       "/app/commands/decidim/admin/transfer_user.rb" => "7cf11abc98c3a0c4a656ab96c220dd6a", # ephemeral participation overrides
-      "/app/controllers/decidim/admin/conflicts_controller.rb" => "8f05066b21f6dd6e3e6511e3f1b45f02", # ephemeral participation overrides
+      "/app/controllers/decidim/admin/conflicts_controller.rb" => "8f05066b21f6dd6e3e6511e3f1b45f02", # ephemeral participation overrides and ignore deleted users on index
       "/app/forms/decidim/admin/component_form.rb" => "0455dd26580817470fd7096ef6b08315", # ephemeral participation overrides
       "/app/forms/decidim/admin/permissions_form.rb" => "f68d00a490e84524ce3aebe6f71d829a" # ephemeral participation overrides
     }


### PR DESCRIPTION
#### :tophat: What? Why?

Remove deleted users from results on the conflicts admin endpoint, so it will take less time to render the page.

A better solution would be include a pagination in this page.