### PR TITLE
Bump decidim version from `6e50c98a52` to `09d0799e80`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/AjuntamentdeBarcelona/decidim
-  revision: 6e50c98a52907d8e830301d8e2a02c27ec5246c6
+  revision: 09d0799e802783c08154c70522e2edabc03aecab
   branch: release/0.28-stable-bcn
   specs:
     decidim (0.28.4)


### PR DESCRIPTION
#### :tophat: What? Why?
Bump decidim version including some official backports for bugfixes and one for a feature.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/13561
- Related to https://github.com/decidim/decidim/pull/13588
- Related to https://github.com/decidim/decidim/pull/13590
- Related to https://github.com/decidim/decidim/pull/13022
