### PR TITLE
Fix S3 public bucket configuration

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -97,7 +97,7 @@ storage_default: &storage_default
   provider: <%= Decidim::Env.new("STORAGE_PROVIDER", "local").to_s %>
   cdn_host: <%= ENV["STORAGE_CDN_HOST"] %>
   s3:
-    public: <%= Decidim::Env.new("AWS_PUBLIC", "false").to_boolean_string %>
+    public: <%= Decidim::Env.new("AWS_PUBLIC", "false").present? %>
     access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
     secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
     region: <%= ENV["AWS_REGION"] %>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,7 @@ local:
 
 s3:
   service: S3
-  public: <%= Rails.application.secrets.dig(:storage, :s3, :public) %>
+  <%= "public: true" if Rails.application.secrets.dig(:storage, :s3, :public) %>
   access_key_id: <%= Rails.application.secrets.dig(:storage, :s3, :access_key_id) %>
   secret_access_key: <%= Rails.application.secrets.dig(:storage, :s3, :secret_access_key) %>
   bucket: <%= Rails.application.secrets.dig(:storage, :s3, :bucket) %>


### PR DESCRIPTION
#### :tophat: What? Why?
The previous configuration was not working as expected as it returned `true` every time an environment variable `AWS_PUBLIC` existed, ignoring its value.

This configuration will only include the line `public: true` in the `s3` storage configuration if the environment variable exists and the value is different than `0`, `false`, or `no`.

#### :pushpin: Related Issues
- Related to https://github.com/AjuntamentdeBarcelona/decidim-barcelona/pull/579

