### PR TITLE
Proposal index page performance improvements

### DIFF
--- a/app/views/decidim/proposals/index.html.erb
+++ b/app/views/decidim/proposals/index.html.erb
@@ -1,0 +1,44 @@
+<% add_decidim_page_title(t("name", scope: "decidim.components.proposals")) %>
+
+<% append_stylesheet_pack_tag "decidim_proposals", media: "all" %>
+<% append_javascript_pack_tag "decidim_proposals" %>
+
+<% content_for :aside do %>
+  <h1 id="proposals-count" class="title-decorator"><%= component_name %></h1>
+
+  <div class="proposal-list__aside__button-container">
+    <% if current_settings.creation_enabled && current_component.participatory_space.can_participate?(current_user) %>
+      <%= action_authorized_link_to :create, new_proposal_path, class: "button button__xl button__secondary w-full", data: { "redirect_url" => new_proposal_path } do %>
+        <span><%= t("new_proposal", scope: "decidim.proposals.proposals.index") %></span>
+        <%= icon "add-line" %>
+      <% end %>
+    <% end %>
+
+    <% if component_settings.collaborative_drafts_enabled? %>
+      <%= link_to collaborative_drafts_path, class: "button button__sm button__transparent-secondary" do %>
+        <span><%= t("collaborative_drafts_list", scope: "decidim.proposals.proposals.index") %></span>
+        <%= icon "edit-2-line" %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <%= render layout: "decidim/shared/filters", locals: { filter_sections: , search_variable: :search_text_cont, skip_to_id: "proposals" } do %>
+    <%= hidden_field_tag :order, order, id: nil, class: "order_filter" %>
+  <% end %>
+<% end %>
+
+<%= render layout: "layouts/decidim/shared/layout_two_col" do %>
+
+  <%= render partial: "decidim/shared/component_announcement" %>
+
+  <% if show_voting_rules? %>
+    <section class="layout-main__section">
+      <%= render partial: "voting_rules" %>
+    </section>
+  <% end %>
+
+  <section id="proposals" class="layout-main__section layout-main__heading">
+    <%= render partial: "proposals" %>
+  </section>
+
+<% end %>

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.config.to_prepare do
+  default_options = Decidim::Paginable::OPTIONS
+  Decidim::Paginable.send(:remove_const, :OPTIONS)
+  Decidim::Paginable::OPTIONS = (default_options + [10]).uniq.sort.freeze
+
   Decidim::PaginateHelper.include(Decidim::PaginateHelperOverride)
   Decidim::Initiatives::Admin::Permissions.prepend(Decidim::Initiatives::Admin::PermissionsOverride)
   Decidim::SearchResourceFieldsMapper.prepend(Decidim::Overrides::SearchResourceFieldsMapper)

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -11,7 +11,7 @@ checksums = [
     files: {
       "/app/helpers/decidim/paginate_helper.rb" => "6fd69359386319d678c7a17cf64de4d9",
       "/app/controllers/decidim/application_controller.rb" => "e86fe37834b061828536f9417fe56cd1", # ephemeral participation overrides
-      "/app/controllers/concerns/decidim/paginable.rb" => "a42381a0883c92df189ac61cebea3047", # update per_page method in assemblies_controller_override.rb
+      "/app/controllers/concerns/decidim/paginable.rb" => "a42381a0883c92df189ac61cebea3047", # update per_page method in assemblies_controller_override.rb and include 10 in OPTIONS constant
       "/app/helpers/decidim/decidim_form_helper.rb" => "c534a1faa8da83aab5b2190f9d7534c3", # ephemeral participation overrides
       "/app/models/decidim/component.rb" => "ec2a03817027336392f1e9e0893309ab", # ephemeral participation overrides
       "/app/models/decidim/organization.rb" => "04eaf4467a1e0d891251c5cedf71f5e4", # ephemeral participation overrides

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -116,7 +116,7 @@ checksums = [
     files: {
       "/app/helpers/decidim/proposals/application_helper.rb" => "c17dd875a166cd0cd3c09b0e596ebef5",
       "/app/presenters/decidim/proposals/proposal_presenter.rb" => "bbc7cee02125c1f8cf909219e48af337",
-      "/app/views/decidim/proposals/index.html.erb" => "48b62ae409b6ed736375772946ef2aa9" # remove map from index page
+      "/app/views/decidim/proposals/proposals/index.html.erb" => "48b62ae409b6ed736375772946ef2aa9" # remove map from index page
     }
   },
   {

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -115,7 +115,8 @@ checksums = [
     package: "decidim-proposals",
     files: {
       "/app/helpers/decidim/proposals/application_helper.rb" => "c17dd875a166cd0cd3c09b0e596ebef5",
-      "/app/presenters/decidim/proposals/proposal_presenter.rb" => "bbc7cee02125c1f8cf909219e48af337"
+      "/app/presenters/decidim/proposals/proposal_presenter.rb" => "bbc7cee02125c1f8cf909219e48af337",
+      "/app/views/decidim/proposals/index.html.erb" => "48b62ae409b6ed736375772946ef2aa9" # remove map from index page
     }
   },
   {

--- a/spec/system/assemblies_spec.rb
+++ b/spec/system/assemblies_spec.rb
@@ -20,7 +20,6 @@ describe "Assemblies" do
 
       it "lists 25 assemblies per page" do
         within "#assemblies-grid" do
-          expect(page).to have_content("Results per page:\n25")
           expect(page).to have_css("[id^=assembly_]", count: 25)
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

- Paginate by 10 elements by default
- Remove map from the index page of the proposals component
