### PR TITLE
Allow non-SSL connection with timestamp service

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "version": "0.1.0",
   "engines": {
     "node": "18.17.1",
-    "npm": ">=9.6.7",
+    "npm": "9.6.7",
     "yarn": "~1.22.1"
   },
   "browserslist": [


### PR DESCRIPTION
#### :tophat: What? Why?

AOC is returning an `SSL certificate problem: certificate has expired` error when we request that they create a signature. We are disabling SSL verification temporarily while they fix the error on their side. 

We must create an environment variable `TIMESTAMP_SERVICE_SKIP_SSL=true` to enable this. Otherwise, it will work as before.