### PR TITLE
Disable search through routing

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,9 @@ Rails.application.routes.draw do
     post :import_results, to: "decidim/accountability/admin/import_results#create"
   end
 
+  # Temporal fix for disabling global search until we fix the performance with a big database
+  match "/search", to: ->(_) { [404, {}, ["Not Found"]] }, via: :all
+
   mount Decidim::Core::Engine => "/"
   mount Decidim::Stats::Engine, at: "/stats", as: "decidim_stats"
   mount Decidim::EphemeralParticipation::Engine, at: "/", as: "decidim_ephemeral_participation"


### PR DESCRIPTION
#### :tophat: What? Why?

We're currently seeing performance degradation related to the search functionality. We've removed the search bar with code, but someone found the URL and it's accessing directly.

As we currently don't have the time to fix the actual issue, we're adding a temporal workaround for this bug by disabling the search page.
  