### PR TITLE
Restore deleted methods by decidim used in overridden views

### DIFF
--- a/app/helpers/concerns/decidim/accountability/application_helper_override.rb
+++ b/app/helpers/concerns/decidim/accountability/application_helper_override.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Accountability
+    module ApplicationHelperOverride
+      extend ActiveSupport::Concern
+
+      included do
+        def display_count(count)
+          heading_parent_level_results(count)
+        end
+
+        def heading_parent_level_results(count)
+          if component_settings.respond_to?(:heading_parent_level_results) && (text = translated_attribute(component_settings.heading_parent_level_results).presence)
+            pluralize(count, text)
+          else
+            t("results.count.results_count", scope: "decidim.accountability", count:)
+          end
+        end
+
+        def categories_label
+          if component_settings.respond_to?(:categories_label) && (text = translated_attribute(component_settings.categories_label).presence)
+            text
+          else
+            t("results.home.categories_label", scope: "decidim.accountability")
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -22,4 +22,5 @@ Rails.application.config.to_prepare do
   Decidim::Forms::QuestionnaireUserAnswers.include(Decidim::Forms::QuestionnaireUserAnswersOverride)
   Decidim::Proposals::ApplicationHelper.include(Decidim::Proposals::ApplicationHelperOverride)
   Decidim::Assemblies::AssembliesController.include(Decidim::Assemblies::AssembliesControllerOverride)
+  Decidim::Accountability::ApplicationHelper.include(Decidim::Accountability::ApplicationHelperOverride)
 end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -73,6 +73,7 @@ checksums = [
   {
     package: "decidim-accountability",
     files: {
+      "/app/helpers/decidim/accountability/application_helper.rb" => "944e9a9bfc994c4b4018f3171aeb0a4c",
       "/app/views/decidim/accountability/admin/results/_form.html.erb" => "980e3f623300704e209f860e1859b507",
       "/app/views/decidim/accountability/admin/results/index.html.erb" => "966e67905bfc82176c7d42dbec855f3e",
       "/app/views/decidim/participatory_spaces/_result.html.erb" => "7565cfff63e0e70bc7286d86bf5b162e",


### PR DESCRIPTION
#### :tophat: What? Why?

During the redesign of Decidim performed in v0.28, some of the views were changed, and some methods became unused. They were deleted in v0.29, but we still have some overridden views using them, so we need to restore them to avoid exceptions while loading some pages.

#### :pushpin: Related Issues

- Related to https://github.com/decidim/decidim/pull/12698
- Related to https://github.com/decidim/decidim/pull/12853
