### PR TITLE
Downgrade `wicked_pdf` from 2.8.0 to 2.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-DECIDIM_VERSION = { git: "https://github.com/AjuntamentdeBarcelona/decidim", branch: "feature/proposal-voting" }.freeze
+DECIDIM_VERSION = { git: "https://github.com/AjuntamentdeBarcelona/decidim", branch: "deps/wicked_pdf/2.7.0" }.freeze
 
 ruby RUBY_VERSION
 

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem "decidim-term_customizer", git: "https://github.com/Platoniq/decidim-module-
 gem "decidim-vocdoni", git: "https://github.com/Platoniq/decidim-module-vocdoni", branch: "main"
 
 gem "origami"
-gem "wicked_pdf"
+gem "wicked_pdf", "~> 2.7.0"
 
 gem "progressbar"
 gem "puma"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-DECIDIM_VERSION = { git: "https://github.com/AjuntamentdeBarcelona/decidim", branch: "deps/wicked_pdf/2.7.0" }.freeze
+DECIDIM_VERSION = { git: "https://github.com/AjuntamentdeBarcelona/decidim", branch: "release/0.29-stable-bcn" }.freeze
 
 ruby RUBY_VERSION
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1012,7 +1012,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wicked_pdf (2.8.0)
+    wicked_pdf (2.7.0)
       activesupport
     wisper (2.0.1)
     wisper-rspec (1.1.0)
@@ -1081,7 +1081,7 @@ DEPENDENCIES
   sidekiq
   stackprof
   web-console
-  wicked_pdf
+  wicked_pdf (~> 2.7.0)
 
 RUBY VERSION
    ruby 3.2.6p234

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/AjuntamentdeBarcelona/decidim
-  revision: cfd65d3c162d8a5e626c0ef1275881a291ce9e0a
-  branch: feature/proposal-voting
+  revision: e6d15df1ac7e7cc5e699b98d1a608374289588ff
+  branch: deps/wicked_pdf/2.7.0
   specs:
     decidim (0.29.2)
       decidim-accountability (= 0.29.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/AjuntamentdeBarcelona/decidim
-  revision: e6d15df1ac7e7cc5e699b98d1a608374289588ff
-  branch: deps/wicked_pdf/2.7.0
+  revision: 081adb38420c2b184dbebb5807d5d4409db3085a
+  branch: release/0.29-stable-bcn
   specs:
     decidim (0.29.2)
       decidim-accountability (= 0.29.2)

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-WickedPdf.config[:use_sprockets] = false


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes the error below

```
ActionView::Template::Error uninitialized constant WickedPdf::WickedPdfHelper::Assets::SprocketsEnvironment::Sprockets 
```

#### :pushpin: Related Issues

- Related to https://github.com/mileszs/wicked_pdf/issues/1102
- Related to https://github.com/AjuntamentdeBarcelona/decidim-barcelona/pull/615


