### PR TITLE
Remove overrides for budget summary messages

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -263,10 +263,6 @@ ca:
               districte i no es pot afegir. Si ho desitges, pots eliminar un projecte
               ja seleccionat del districte per afegir aquest.
         budget_summary:
-          cancel_order: eliminar el teu vot i començar a votar de nou
-          checked_out:
-            description: Ja has votat en aquest districte. Si has canviat d'idea,
-              pots %{cancel_link}.
           minimum_projects_rule:
             instruction: Selecciona <strong>com a mínim %{minimum_number} projectes</strong>
               del districte i vota segons les teves preferències per a definir el

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -264,10 +264,6 @@ es:
               distrito y no se puede añadir. Si lo deseas, puedes eliminar un proyecto
               que ya hayas seleccionado del distrito para añadir este.
         budget_summary:
-          cancel_order: eliminar tu voto y empezar a votar de nuevo
-          checked_out:
-            description: Ya has votado en este distrito. Si has cambiado de idea,
-              puedes %{cancel_link}.
           minimum_projects_rule:
             instruction: Selecciona <strong>al menos %{minimum_number} proyectos</strong>
               del distrito y vota de acuerdo a tus preferencias para definir el presupuesto.


### PR DESCRIPTION
#### :tophat: What? Why?


While doing UX testing, we found out two mini bugs with the budgets summary after voting;

- There's a missing string interpolation (`%{cancel_link}`)
- The message in the button is too large

This PR fixes them by removing the overrides and using the default values from upstream (decidim defaults)

#### :clipboard: Testing

. Sign in as user
. Vote in a budgets component
. See the summary after voting

### :camera: Screenshots (optional)

#### Before

![image](https://github.com/user-attachments/assets/b78ef1e7-1c2c-4119-a3d8-aad1b4acc8e6)

#### After

![image](https://github.com/user-attachments/assets/70402cd6-b53a-400e-81db-0bb69147af59)

