### PR TITLE
Improve the budgets' limit message when going to another budget

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -253,6 +253,10 @@ ca:
           scope: Districte
         name: El padró (ephemeral)
     budgets:
+      limit_announcement:
+        limit_reached: |-
+          Tens vots actius a %{links}. Pots votar un màxim de 2 districtes:
+          El d’empadronament i un altre. Si vols votar aquest pressupost has d'<a href="%{landing_path}">esborrar el teu vot i començar de nou</a>.
       projects:
         budget_confirm:
           description: Aquests són els projectes que has seleccionat i que estàs a

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -254,6 +254,10 @@ es:
           scope_id: Distrito
         name: El padrón (ephemeral)
     budgets:
+      limit_announcement:
+        limit_reached: |-
+          Tienes votos activos en %{links}. Puedes votar en un máximo de 2 distritos:
+          El de empadronamiento y otro. Si quieres votar en este presupuesto debes <a href="%{landing_path}">borrar tu voto y empezar de nuevo</a>.
       projects:
         budget_confirm:
           description: Estos son los proyectos que has elegido y que estás a punto


### PR DESCRIPTION
#### :tophat: What? Why?

Improve the budgets' limit message when going to another budget

#### Testing

0. Starting with the decidim-barcelona app, with the ephemeral_backport branch
1. Sign in as admin
2. In the Budget's Component, configure the "Budgets 2025 (ephemeral): allows to Vote in the participant's district and in another of free choice." workflow 
5. Add Permissions with the Ephemeral verification in the component
4. Configure 3 budgets with 3 different Scopes with projects in there.
5. Go to vote and verify with a Scope
8. Finish the vote in your Budget's Scope (Ciutat Vella)
10. Go to another Budgets' scope. Check one project. Do not emit the vote.
10. Go to the third Budgets' scope. See that you have this message (both in Catalan and in Spanish)  

### :camera: Screenshots (optional)

![image](https://github.com/user-attachments/assets/ae26e29c-ca72-431b-8658-e92f3c180819)

![image](https://github.com/user-attachments/assets/ffd8392b-8283-48e9-ba82-0737364a7405)

