### PR TITLE
Fix `secret_key_base size` validation

### DIFF
--- a/app/cells/concerns/decidim/system/system_checks_cell_override.rb
+++ b/app/cells/concerns/decidim/system/system_checks_cell_override.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module System
+    module SystemChecksCellOverride
+      extend ActiveSupport::Concern
+
+      included do
+        private
+
+        def correct_secret_key_base?
+          Rails.application.secrets.secret_key_base&.length == 64
+        end
+      end
+    end
+  end
+end

--- a/app/forms/concerns/decidim/system/base_organization_form_override.rb
+++ b/app/forms/concerns/decidim/system/base_organization_form_override.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module System
+    module BaseOrganizationFormOverride
+      extend ActiveSupport::Concern
+
+      included do
+        def validate_secret_key_base_for_encryption
+          return if Rails.application.secrets.secret_key_base&.length == 64
+
+          errors.add(:password, I18n.t("activemodel.errors.models.organization.attributes.password.secret_key"))
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.config.to_prepare do
+  Decidim::System::SystemChecksCell.include(Decidim::System::SystemChecksCellOverride)
+  Decidim::System::BaseOrganizationForm.include(Decidim::System::BaseOrganizationFormOverride)
   Decidim::PaginateHelper.include(Decidim::PaginateHelperOverride)
   Decidim::Initiatives::Admin::Permissions.prepend(Decidim::Initiatives::Admin::PermissionsOverride)
   Decidim::SearchResourceFieldsMapper.prepend(Decidim::Overrides::SearchResourceFieldsMapper)

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -65,6 +65,8 @@ checksums = [
   {
     package: "decidim-system",
     files: {
+      "/app/cells/decidim/system/system_checks_cell.rb" => "b59c845eb450b08ae9bed94260d1b2e7",
+      "/app/forms/decidim/system/base_organization_form.rb" => "711d78632492cf9fd7b3356f38b9ba72",
       "/app/forms/decidim/system/update_organization_form.rb" => "3fe09b001d83030207a6f5faa256ac3b", # ephemeral participation overrides
       "/app/views/decidim/system/organizations/edit.html.erb" => "01bff555e3d7680868fff210d3c393b2", # ephemeral participation overrides
       "/app/views/decidim/system/organizations/new.html.erb" => "4916cdb428d89de5afe60e279d64112f" # ephemeral participation overrides


### PR DESCRIPTION
#### :tophat: What? Why?
The `secret_key_base` size we have in our server does not match with the size proposed by decidim. Instead of changing it, we change the expected size in the validations, so we will be able to update an organization from the system page again.
