### PR TITLE
Main header resize

### DIFF
--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -112,6 +112,24 @@
     font-size: 1rem !important;
     font-weight: 600 !important;
   }
+
+  .main-bar {
+    height: 50% !important;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+  }
+
+  .bcn-cat-link a {
+    font-size: 14px !important;
+  }
+
+  .bcn-logo img {
+    width: 1.5rem;
+  }
+
+  .brand-bar.home__section {
+    height: 1.5rem;
+  }
 }
 
 .brand-bar {


### PR DESCRIPTION
#### :tophat: What? Why?
Header in mobile views was taking too much room.

### :camera: Screenshots (optional)
![image](https://github.com/user-attachments/assets/76465cdb-72db-42b9-b9fa-382d8cf06159)

![Description](URL)
