### PR TITLE
Bump decidim version from `d518932` to `18b810a`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/AjuntamentdeBarcelona/decidim
-  revision: f4348df74b82dde4f1a32e178a0943868f8e6d69
+  revision: 18b810ae2fcc971f44eb0c2c753be926303b1285
   branch: release/0.29-stable-bcn
   specs:
     decidim (0.29.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/AjuntamentdeBarcelona/decidim
-  revision: d51893238185cdf97dd0ae985d80df514dc348a8
+  revision: f4348df74b82dde4f1a32e178a0943868f8e6d69
   branch: release/0.29-stable-bcn
   specs:
     decidim (0.29.2)


### PR DESCRIPTION
#### :tophat: What? Why?

Bump decidim version including the `nicknamize` method mandatory parameter backport: https://github.com/decidim/decidim/pull/14683

