### PR TITLE
Fix default static here maps URL

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -111,7 +111,7 @@ Decidim.configure do |config|
     dynamic_provider = Rails.application.secrets.maps[:dynamic_provider]
     dynamic_url = Rails.application.secrets.maps[:dynamic_url]
     static_url = Rails.application.secrets.maps[:static_url]
-    static_url = "https://image.maps.ls.hereapi.com/mia/1.6/mapview" if static_provider == "here" && static_url.blank?
+    static_url = "https://image.maps.hereapi.com/mia/v3/base/mc/overlay" if static_provider == "here" && static_url.blank?
     config.maps = {
       provider: static_provider,
       api_key: Rails.application.secrets.maps[:static_api_key],


### PR DESCRIPTION
#### :tophat: What? Why?
In https://github.com/decidim/decidim/pull/14180, we transitioned from version v1 to version v3 of Here Maps. However, the default URL in the initializer was not modified. To address this issue, we can define the `MAPS_STATIC_URL` environment variable. However, to facilitate maintenance, we have modified the default URL in the initializer as specified in the release notes: https://github.com/decidim/decidim/releases/tag/v0.29.3

#### :pushpin: Related Issues
- Related to DECIDIM-1115