### PR TITLE
Avoid having empty external ids on accountability results

### DIFF
--- a/app/models/concerns/decidim/accountability/result_override.rb
+++ b/app/models/concerns/decidim/accountability/result_override.rb
@@ -6,8 +6,16 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
+        before_validation :remove_external_id, if: -> { external_id.blank? }
+
         def self.not_computable_results
           [11_098, 11_131]
+        end
+
+        private
+
+        def remove_external_id
+          self.external_id = nil
         end
       end
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,6 +3,7 @@
 require "decidim/core/test/factories"
 require "decidim/assemblies/test/factories"
 require "decidim/initiatives/test/factories"
+require "decidim/accountability/test/factories"
 
 FactoryBot.define do
   sequence(:valid_jwt) do |_n|

--- a/spec/models/decidim/accountability/result_spec.rb
+++ b/spec/models/decidim/accountability/result_spec.rb
@@ -19,6 +19,7 @@ module Decidim
 
           it "is valid" do
             expect { result.save! }.not_to raise_error
+            expect(result.external_id).to be_nil
           end
         end
 
@@ -27,6 +28,7 @@ module Decidim
 
           it "is valid" do
             expect { result.save! }.not_to raise_error
+            expect(result.external_id).to be_nil
           end
         end
 
@@ -42,6 +44,7 @@ module Decidim
 
             it "is valid" do
               expect { result.save! }.not_to raise_error
+              expect(result.external_id).to eq(external_id)
             end
           end
 
@@ -50,6 +53,7 @@ module Decidim
 
             it "is valid" do
               expect { result.save! }.not_to raise_error
+              expect(result.external_id).to eq(external_id)
             end
           end
         end

--- a/spec/models/decidim/accountability/result_spec.rb
+++ b/spec/models/decidim/accountability/result_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Decidim
+  module Accountability
+    describe Result do
+      subject { result }
+
+      let(:result) { create(:result, component:, external_id:) }
+      let(:component) { existing_result.component }
+      let(:external_id) { existing_result.external_id }
+
+      describe "external_id uniqueness by component" do
+        let(:existing_result) { create(:result, external_id: existing_result_external_id) }
+
+        context "when the external_id is nil" do
+          let(:existing_result_external_id) { nil }
+
+          it "is valid" do
+            expect { result.save! }.not_to raise_error
+          end
+        end
+
+        context "when the external_id is empty" do
+          let(:existing_result_external_id) { "" }
+
+          it "is valid" do
+            expect { result.save! }.not_to raise_error
+          end
+        end
+
+        context "when the external_id has a value" do
+          let(:existing_result_external_id) { "external-id" }
+
+          it "is invalid" do
+            expect { result.save! }.to raise_error(ActiveRecord::RecordNotUnique)
+          end
+
+          context "when the component is different" do
+            let(:component) { create(:component, manifest_name: "accountability") }
+
+            it "is valid" do
+              expect { result.save! }.not_to raise_error
+            end
+          end
+
+          context "when the external_id is different" do
+            let(:external_id) { "different-external-id" }
+
+            it "is valid" do
+              expect { result.save! }.not_to raise_error
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

In this decidim instance we have a database unique index for `external_id` and `decidim_component_id` in the `decidim_accountability_results` table. That was causing an error when we have two `Decidim::Accountability::Result` records with repeated external ids for the same component.

We don't know exactly how, (maybe a one-time action of a previous Decidim upgrade) but we had several external ids with an empty string instead of a null, raising the exception described above.

With this solution, we'll avoid this situation as every time we save a `Decidim::Accountability::Result` record, we'll check if the `external_id` is empty converting it into a null value instead.

#### :pushpin: Related Issues

- Related to DECIDIM-1169