### PR TITLE
Add missing queues in sidekiq configuration

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,14 +1,16 @@
 :concurrency: 5
 :queues:
   - [mailers, 4]
+  - [vote_reminder, 2]
+  - [reminders, 2]
   - [default, 2]
   - [newsletter, 2]
   - [newsletters_opt_in, 2]
   - [conference_diplomas, 2]
-  - [decidim_events, 2]
   - [events, 2]
   - [user_report, 2]
   - [block_user, 2]
   - [metrics, 1]
   - [exports, 1]
+  - [close_meeting_reminder, 1]
   - [translations, 1]


### PR DESCRIPTION
#### :tophat: What? Why?

I realized we had some missing queues. This PR updates the list of queues with the ones we should have in our decidim version.