### PR TITLE
Bump `decidim-internal_evaluation` version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "decidim-dataviz", path: "decidim-dataviz"
 gem "decidim-stats", path: "decidim-stats"
 
 gem "decidim-decidim_awesome", git: "https://github.com/decidim-ice/decidim-module-decidim_awesome", branch: "main"
-gem "decidim-internal_evaluation", git: "https://github.com/AjuntamentdeBarcelona/decidim-internal-evaluation-module", branch: "fix/open-data-export"
+gem "decidim-internal_evaluation", git: "https://github.com/AjuntamentdeBarcelona/decidim-internal-evaluation-module", branch: "release/0.29-stable"
 # gem "decidim-kids", git: "https://github.com/AjuntamentdeBarcelona/decidim-module-kids", branch: "main"
 gem "decidim-navigation_maps", git: "https://github.com/Platoniq/decidim-module-navigation_maps", branch: "main"
 gem "decidim-term_customizer", git: "https://github.com/Platoniq/decidim-module-term_customizer", branch: "master"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,8 +190,8 @@ GIT
 
 GIT
   remote: https://github.com/AjuntamentdeBarcelona/decidim-internal-evaluation-module
-  revision: ca18e953316c48676adf9794922cdfcf5087a55f
-  branch: fix/open-data-export
+  revision: 6b2c6a72aa2396d9ec02ca082ba1dfb310da83aa
+  branch: release/0.29-stable
   specs:
     decidim-internal_evaluation (0.0.1)
       decidim-core (>= 0.29.0)


### PR DESCRIPTION
#### :tophat: What? Why?

Fix Open Data export issue with the internal evaluation module

#### :pushpin: Related Issues

- Related to DECIDIM-1270
