### PR TITLE
Adds backward compatibility for Active Storage signed URLs

### DIFF
--- a/config/initializers/active_storage_rotation.rb
+++ b/config/initializers/active_storage_rotation.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Adds backward compatibility for Active Storage signed URLs created before
+# the upgrade to Rails 7.2 (Decidim 0.31).
+#
+# load_defaults 7.2 sets key_generator_hash_digest_class to SHA256, but old
+# signed blob URLs embedded in content fields were signed with SHA1-derived
+# keys. Without rotation, those URLs return 404.
+#
+# This keeps SHA256 for new signatures while accepting old SHA1 signatures.
+Rails.application.config.after_initialize do
+  next if Rails.application.secret_key_base.blank?
+
+  old_secret = ActiveSupport::KeyGenerator.new(
+    Rails.application.secret_key_base,
+    iterations: 1000,
+    hash_digest_class: OpenSSL::Digest::SHA1
+  ).generate_key("ActiveStorage")
+
+  new_secret = Rails.application.key_generator.generate_key("ActiveStorage")
+
+  verifier = ActiveSupport::MessageVerifier.new(new_secret)
+  verifier.rotate(old_secret)
+
+  ActiveStorage::Blob.instance_variable_set(:@signed_id_verifier, verifier)
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Adds a Rails initializer that rotates Active Storage's signed_id_verifier so it accepts both old SHA1-based signatures and new SHA256-based signatures, restoring access to all previously embedded assets

#### :pushpin: Related Issues


#### :clipboard: Subtasks


### :camera: Screenshots (optional)
Fixes 404 error:
<img width="1147" height="753" alt="image" src="https://github.com/user-attachments/assets/1d1e61e4-3d64-40a1-9a44-cb917194e58d" />



