### PR TITLE
Prevent invalid CSRF token error while using ephemeral authorization

### DIFF
--- a/app/controllers/concerns/decidim/verifications/authorizations_controller_override.rb
+++ b/app/controllers/concerns/decidim/verifications/authorizations_controller_override.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    module AuthorizationsControllerOverride
+      extend ActiveSupport::Concern
+
+      included do
+        skip_before_action :verify_authenticity_token, only: :renew_onboarding_data # rubocop:disable Rails/LexicallyScopedActionFilter
+      end
+    end
+  end
+end

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -37,4 +37,5 @@ Rails.application.config.to_prepare do
   Decidim::Accountability::ApplicationHelper.include(Decidim::Accountability::ApplicationHelperOverride)
   Decidim::Exporters::InitiativeVotesPDF.prepend(Decidim::Overrides::Exporters::InitiativeVotesPdf)
   Decidim::Initiatives::ApplicationFormPDF.prepend(Decidim::Overrides::Initiatives::ApplicationFormPdf)
+  Decidim::Verifications::AuthorizationsController.include(Decidim::Verifications::AuthorizationsControllerOverride)
 end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -114,6 +114,12 @@ checksums = [
     }
   },
   {
+    package: "decidim-verifications",
+    files: {
+      "/app/controllers/decidim/verifications/authorizations_controller.rb" => "cfcb7af376bda64dbd3e2d5db87c6859"
+    }
+  },
+  {
     package: "decidim-system",
     files: {
       "/app/cells/decidim/system/system_checks_cell.rb" => "42e1b5525b5a9df1705cae3ef29ad9c4",


### PR DESCRIPTION
#### :tophat: What? Why?

Prevent invalid CSRF token error while using ephemeral authorization with unregistered user

#### :pushpin: Related Issues

- Related to DECIDIM-1347
