### PR TITLE
Include accesibility link in footer

### DIFF
--- a/app/views/layouts/decidim/footer/_main_legal.html.erb
+++ b/app/views/layouts/decidim/footer/_main_legal.html.erb
@@ -1,0 +1,11 @@
+<ul class="flex flex-col gap-6 md:flex-row md:gap-10 text-sm text-white [&_a]:underline">
+  <li>
+    <%= link_to t("layouts.decidim.footer.terms_of_service"), decidim.page_path("terms-of-service") %>
+  </li>
+  <li>
+    <a href="#" role="button" data-dialog-open="dc-modal"><%= t("layouts.decidim.footer.data_consent_settings") %></a>
+  </li>
+  <li>
+    <%= link_to t("layouts.decidim.footer.accessibility"), decidim.page_path("accessibilitat") %>
+  </li>
+</ul>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -522,6 +522,7 @@ ca:
         awesome_config:
           taxonomies: Taxonomies
       footer:
+        accessibility: Accessibilitat
         bcn_logo: Logotip de l'Ajuntament de Barcelona
       header:
         main:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,7 @@ en:
   layouts:
     decidim:
       footer:
+        accessibility: Accessibility
         bcn_logo: Barcelona City Council Logo
       header:
         main:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -513,6 +513,7 @@ es:
   layouts:
     decidim:
       footer:
+        accessibility: Accesibilidad
         bcn_logo: Logotipo del Ayuntamiento de Barcelona
       header:
         main:

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -55,6 +55,7 @@ checksums = [
       "/app/helpers/decidim/paginate_helper.rb" => "d7a08fda6fff5c0e43fbea2a83cd5346",
       "/app/packs/stylesheets/decidim/legacy/email.scss" => "7edc1be320cdd9605bec4e0caba132d5",
       "/app/presenters/decidim/official_author_presenter.rb" => "dbfb2fefa1c75d703e65443cd68014c2",
+      "/app/views/layouts/decidim/footer/_main_legal.html.erb" => "d4d3e477b5eb6840b915a836b1a7f417",
       "/app/views/layouts/decidim/footer/_mini.html.erb" => "c67cc97db27cdcf926f60682e399f688",
       "/app/views/layouts/decidim/header/_main.html.erb" => "a090eeca739613446d2eab8f4de513b1",
       "/app/views/layouts/decidim/mailer.html.erb" => "6a08103c75e5db737a38cd365428a177",


### PR DESCRIPTION
#### :tophat: What? Why?
DECIDIM-1378: Añadir el apartado de Accesibilidad en el pie de página de decidim.barcelona


#### :pushpin: Related Issues

#### :clipboard: Subtasks


### :camera: Screenshots (optional)
Desktop:

<img width="1739" height="553" alt="image" src="https://github.com/user-attachments/assets/c0eda626-f2a9-474c-88dc-810dcb392ada" />

Mobile:

<img width="493" height="427" alt="image" src="https://github.com/user-attachments/assets/21b217b3-10a1-4437-9e2c-9c5a799c2dcc" />


