### PR TITLE
Fix condition questions in surveys

### DIFF
--- a/app/models/concerns/decidim/forms/question_override.rb
+++ b/app/models/concerns/decidim/forms/question_override.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Forms
+    module QuestionOverride
+      extend ActiveSupport::Concern
+
+      included do
+        has_many :display_conditions_for_other_questions,
+                 class_name: "DisplayCondition",
+                 foreign_key: "decidim_condition_question_id",
+                 dependent: :destroy,
+                 inverse_of: :condition_question,
+                 counter_cache: :display_conditions_for_other_questions_count
+      end
+    end
+  end
+end

--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -9,6 +9,7 @@ Rails.application.config.to_prepare do
   Decidim::SearchResourceFieldsMapper.prepend(Decidim::Overrides::SearchResourceFieldsMapper)
   Decidim::Initiatives::InitiativeMetadataGCell.include(Decidim::Initiatives::InitiativeMetadataGCellOverride)
   Decidim::Forms::UserResponsesSerializer.prepend(Decidim::Overrides::Forms::UserResponsesSerializer)
+  Decidim::Forms::Question.include(Decidim::Forms::QuestionOverride)
   Decidim::Initiative.include(Decidim::InitiativeOverride)
   Decidim::InitiativesVote.include(Decidim::InitiativesVoteOverride)
   Decidim::Initiatives::InitiativeForm.include(Decidim::Initiatives::InitiativeFormOverride)

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -66,6 +66,7 @@ checksums = [
   {
     package: "decidim-forms",
     files: {
+      "/app/models/decidim/forms/question.rb" => "92531f8217998320bfae5ac4d5f8e7e8",
       "/app/queries/decidim/forms/questionnaire_user_responses.rb" => "d9a56ef2b9b1e06040143272adf8d7d0",
       "/app/views/decidim/forms/admin/questionnaires/responses/show.html.erb" => "05f8b5e851ddf60f5d2e62de64c4eb8b",
       "/lib/decidim/forms/user_responses_serializer.rb" => "71762d1083ba1bdf4c0acd44a0cc7371"

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -66,7 +66,7 @@ checksums = [
   {
     package: "decidim-forms",
     files: {
-      "/app/models/decidim/forms/question.rb" => "92531f8217998320bfae5ac4d5f8e7e8",
+      "/app/models/decidim/forms/question.rb" => "92531f8217998320bfae5ac4d5f8e7e8", # fix display_conditions_for_other_questions inverse_of in question_override.rb
       "/app/queries/decidim/forms/questionnaire_user_responses.rb" => "d9a56ef2b9b1e06040143272adf8d7d0",
       "/app/views/decidim/forms/admin/questionnaires/responses/show.html.erb" => "05f8b5e851ddf60f5d2e62de64c4eb8b",
       "/lib/decidim/forms/user_responses_serializer.rb" => "71762d1083ba1bdf4c0acd44a0cc7371"


### PR DESCRIPTION
#### :tophat: What? Why?
Decidim::Forms::Question declares a wrong inverse_of. Because of it, assigning the condition_question association object to a display condition silently overwrites the owner FK (decidim_question_id) with the condition question's id, producing a self-reference, decidim_question_id == decidim_condition_question_id. That produces multiple errors when trying to add conditional questions to a survey.

The correct inverse of display_conditions_for_other_questions is :condition_question, not :question. The association is keyed on decidim_condition_question_id but claims its inverse is the belongs_to keyed on decidim_question_id, that's the inconsistence.


#### :pushpin: Related Issues


#### :clipboard: Subtasks


### :camera: Screenshots (optional)

Error produced before the fix:

<img width="779" height="1206" alt="image" src="https://github.com/user-attachments/assets/37569235-10e8-45ac-b002-74ac01ea804a" />

After the fix, it allows conditional questions to be added without any error:

<img width="459" height="104" alt="image" src="https://github.com/user-attachments/assets/949bea1b-0477-435f-85d6-446ec9b34353" />

