### PR TITLE
Include new stat to display meetings attendees count

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,7 +10,7 @@ RSpec/DescribeClass:
   Exclude:
     - 'decidim-census_sms/spec/system/census_sms_authorization_spec.rb'
     - 'spec/system/census16_authorization_spec.rb'
-    - 'spec/lib/in_person_attendees_count_stat_spec.rb'
+    - 'spec/lib/meetings_attendees_count_stat_spec.rb'
 
 RSpec/PendingWithoutReason:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,6 +10,7 @@ RSpec/DescribeClass:
   Exclude:
     - 'decidim-census_sms/spec/system/census_sms_authorization_spec.rb'
     - 'spec/system/census16_authorization_spec.rb'
+    - 'spec/lib/in_person_attendees_count_stat_spec.rb'
 
 RSpec/PendingWithoutReason:
   Exclude:

--- a/config/initializers/decidim_meetings_stats.rb
+++ b/config/initializers/decidim_meetings_stats.rb
@@ -6,8 +6,6 @@ Decidim.find_component_manifest(:meetings).stats.register(
   admin: false,
   icon_name: "group-line",
   tooltip_key: "meetings_attendees_count_tooltip"
-) do |components, _start_at, _end_at|
-  Decidim::Meetings::Meeting.closed.not_hidden.published
-                            .where(component: components, closing_visible: true)
-                            .sum(:attendees_count)
+) do |components, start_at, end_at|
+  Decidim.find_component_manifest(:meetings).stats.resolve(:attendees_count, components, start_at, end_at)
 end

--- a/config/initializers/decidim_meetings_stats.rb
+++ b/config/initializers/decidim_meetings_stats.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 Decidim.find_component_manifest(:meetings).stats.register(
-  :in_person_attendees_count,
+  :meetings_attendees_count,
   priority: Decidim::StatsRegistry::MEDIUM_PRIORITY,
   admin: false,
   icon_name: "group-line",
-  tooltip_key: "in_person_attendees_count_tooltip"
+  tooltip_key: "meetings_attendees_count_tooltip"
 ) do |components, _start_at, _end_at|
   Decidim::Meetings::Meeting.closed.not_hidden.published
                             .where(component: components, closing_visible: true)
-                            .in_person
                             .sum(:attendees_count)
 end

--- a/config/initializers/decidim_meetings_stats.rb
+++ b/config/initializers/decidim_meetings_stats.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Decidim.find_component_manifest(:meetings).stats.register(
+  :in_person_attendees_count,
+  priority: Decidim::StatsRegistry::MEDIUM_PRIORITY,
+  admin: false,
+  icon_name: "group-line",
+  tooltip_key: "in_person_attendees_count_tooltip"
+) do |components, _start_at, _end_at|
+  Decidim::Meetings::Meeting.closed.not_hidden.published
+                            .where(component: components, closing_visible: true)
+                            .in_person
+                            .sum(:attendees_count)
+end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -447,6 +447,9 @@ ca:
         project_proposals: 'Propostes incloses en aquest projecte:'
     sms:
       text: 'El teu codi per verificar-te a Decidim Barcelona és: %{code}'
+    statistics:
+      in_person_attendees_count: Assistents
+      in_person_attendees_count_tooltip: El nombre total d'assistents de les trobades presencials finalitzades d'aquest espai.
     system:
       dashboard:
         show:

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -448,8 +448,8 @@ ca:
     sms:
       text: 'El teu codi per verificar-te a Decidim Barcelona és: %{code}'
     statistics:
-      in_person_attendees_count: Assistents
-      in_person_attendees_count_tooltip: El nombre total d'assistents de les trobades presencials finalitzades d'aquest espai.
+      meetings_attendees_count: Assistents
+      meetings_attendees_count_tooltip: El nombre total d'assistents a les trobades realitzades en el marc d'aquest espai de participació. Aquesta dada no suma a la dada de Participants.
     system:
       dashboard:
         show:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,9 @@ en:
           register: Register to the meeting
     sms:
       text: 'Your code to be verified at Decidim Barcelona is: %{code}'
+    statistics:
+      in_person_attendees_count: Attendees
+      in_person_attendees_count_tooltip: The total number of attendees of the closed in-person meetings in this space.
   layouts:
     decidim:
       footer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,8 +53,8 @@ en:
     sms:
       text: 'Your code to be verified at Decidim Barcelona is: %{code}'
     statistics:
-      in_person_attendees_count: Attendees
-      in_person_attendees_count_tooltip: The total number of attendees of the closed in-person meetings in this space.
+      meetings_attendees_count: Attendees
+      meetings_attendees_count_tooltip: The total number of attendees of the meetings held within this participation space. This figure is not added to the Participants figure.
   layouts:
     decidim:
       footer:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -444,8 +444,8 @@ es:
     sms:
       text: 'Tu código para verificarte en Decidim Barcelona es: %{code}'
     statistics:
-      in_person_attendees_count: Asistentes
-      in_person_attendees_count_tooltip: El número total de asistentes de los encuentros presenciales finalizados de este espacio.
+      meetings_attendees_count: Asistentes
+      meetings_attendees_count_tooltip: El número total de asistentes en los encuentros realizados en el marco de este espacio de participación. Este dato no suma al dato de Participantes.
     system:
       dashboard:
         show:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -443,6 +443,9 @@ es:
         project_proposals: 'Propuestas incluidas en este proyecto:'
     sms:
       text: 'Tu código para verificarte en Decidim Barcelona es: %{code}'
+    statistics:
+      in_person_attendees_count: Asistentes
+      in_person_attendees_count_tooltip: El número total de asistentes de los encuentros presenciales finalizados de este espacio.
     system:
       dashboard:
         show:

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,6 +4,7 @@ require "decidim/core/test/factories"
 require "decidim/assemblies/test/factories"
 require "decidim/initiatives/test/factories"
 require "decidim/accountability/test/factories"
+require "decidim/meetings/test/factories"
 
 FactoryBot.define do
   sequence(:valid_jwt) do |_n|

--- a/spec/lib/in_person_attendees_count_stat_spec.rb
+++ b/spec/lib/in_person_attendees_count_stat_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "In-person attendees count stat" do
+  subject { stats.resolve(:in_person_attendees_count, components) }
+
+  let(:stats) { Decidim.find_component_manifest(:meetings).stats }
+  let(:component) { create(:meeting_component, :published) }
+  let(:components) { Decidim::Component.where(id: component.id) }
+
+  it "is registered with medium priority and visible to non-admins" do
+    stat = stats.stats.find { |definition| definition[:name] == :in_person_attendees_count }
+
+    expect(stat[:priority]).to eq(Decidim::StatsRegistry::MEDIUM_PRIORITY)
+    expect(stat[:admin]).to be(false)
+  end
+
+  it "sums the attendees of closed, published, in-person meetings" do
+    create(:meeting, :published, :closed, :in_person, component:, attendees_count: 10)
+    create(:meeting, :published, :closed, :in_person, component:, attendees_count: 5)
+
+    expect(subject).to eq(15)
+  end
+
+  it "ignores online and hybrid meetings" do
+    create(:meeting, :published, :closed, :online, component:, attendees_count: 10)
+    create(:meeting, :published, :closed, :hybrid, component:, attendees_count: 20)
+    create(:meeting, :published, :closed, :in_person, component:, attendees_count: 3)
+
+    expect(subject).to eq(3)
+  end
+
+  it "ignores meetings that are not closed" do
+    create(:meeting, :published, :in_person, component:)
+    create(:meeting, :published, :closed, :in_person, component:, attendees_count: 7)
+
+    expect(subject).to eq(7)
+  end
+
+  it "ignores meetings whose closing report is not visible" do
+    create(:meeting, :published, :closed, :in_person, component:, attendees_count: 10, closing_visible: false)
+
+    expect(subject).to eq(0)
+  end
+
+  it "ignores unpublished and hidden meetings" do
+    create(:meeting, :closed, :in_person, component:, attendees_count: 10)
+    create(:meeting, :published, :closed, :in_person, :hidden, component:, attendees_count: 20)
+
+    expect(subject).to eq(0)
+  end
+
+  it "ignores meetings from other components" do
+    other_component = create(:meeting_component, :published)
+    create(:meeting, :published, :closed, :in_person, component: other_component, attendees_count: 10)
+
+    expect(subject).to eq(0)
+  end
+end

--- a/spec/lib/meetings_attendees_count_stat_spec.rb
+++ b/spec/lib/meetings_attendees_count_stat_spec.rb
@@ -2,58 +2,58 @@
 
 require "rails_helper"
 
-describe "In-person attendees count stat" do
-  subject { stats.resolve(:in_person_attendees_count, components) }
+describe "Meetings attendees count stat" do
+  subject { stats.resolve(:meetings_attendees_count, components) }
 
   let(:stats) { Decidim.find_component_manifest(:meetings).stats }
   let(:component) { create(:meeting_component, :published) }
   let(:components) { Decidim::Component.where(id: component.id) }
 
   it "is registered with medium priority and visible to non-admins" do
-    stat = stats.stats.find { |definition| definition[:name] == :in_person_attendees_count }
+    stat = stats.stats.find { |definition| definition[:name] == :meetings_attendees_count }
 
     expect(stat[:priority]).to eq(Decidim::StatsRegistry::MEDIUM_PRIORITY)
     expect(stat[:admin]).to be(false)
   end
 
-  it "sums the attendees of closed, published, in-person meetings" do
-    create(:meeting, :published, :closed, :in_person, component:, attendees_count: 10)
-    create(:meeting, :published, :closed, :in_person, component:, attendees_count: 5)
+  it "sums the attendees of closed and published meetings" do
+    create(:meeting, :published, :closed, component:, attendees_count: 10)
+    create(:meeting, :published, :closed, component:, attendees_count: 5)
 
     expect(subject).to eq(15)
   end
 
-  it "ignores online and hybrid meetings" do
+  it "counts in-person, online and hybrid meetings" do
     create(:meeting, :published, :closed, :online, component:, attendees_count: 10)
     create(:meeting, :published, :closed, :hybrid, component:, attendees_count: 20)
     create(:meeting, :published, :closed, :in_person, component:, attendees_count: 3)
 
-    expect(subject).to eq(3)
+    expect(subject).to eq(33)
   end
 
   it "ignores meetings that are not closed" do
-    create(:meeting, :published, :in_person, component:)
-    create(:meeting, :published, :closed, :in_person, component:, attendees_count: 7)
+    create(:meeting, :published, component:)
+    create(:meeting, :published, :closed, component:, attendees_count: 7)
 
     expect(subject).to eq(7)
   end
 
   it "ignores meetings whose closing report is not visible" do
-    create(:meeting, :published, :closed, :in_person, component:, attendees_count: 10, closing_visible: false)
+    create(:meeting, :published, :closed, component:, attendees_count: 10, closing_visible: false)
 
     expect(subject).to eq(0)
   end
 
   it "ignores unpublished and hidden meetings" do
-    create(:meeting, :closed, :in_person, component:, attendees_count: 10)
-    create(:meeting, :published, :closed, :in_person, :hidden, component:, attendees_count: 20)
+    create(:meeting, :closed, component:, attendees_count: 10)
+    create(:meeting, :published, :closed, :hidden, component:, attendees_count: 20)
 
     expect(subject).to eq(0)
   end
 
   it "ignores meetings from other components" do
     other_component = create(:meeting_component, :published)
-    create(:meeting, :published, :closed, :in_person, component: other_component, attendees_count: 10)
+    create(:meeting, :published, :closed, component: other_component, attendees_count: 10)
 
     expect(subject).to eq(0)
   end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -107,7 +107,9 @@ checksums = [
       "/app/controllers/decidim/meetings/meetings_controller.rb" => "da1a19e72fc0692c259671b9fdc8dc8b",
       "/app/helpers/decidim/meetings/meetings_helper.rb" => "7f393c50d7a01bc24f6a3d08d5590e10",
       "/app/models/decidim/meetings/meeting.rb" => "ffcce46a24c3912e742db2ff79bb2588",
-      "/app/views/decidim/meetings/meetings/_meeting_agenda.html.erb" => "3d0a04c264dd2c88212789e0e5bc803b"
+      "/app/views/decidim/meetings/meetings/_meeting_agenda.html.erb" => "3d0a04c264dd2c88212789e0e5bc803b",
+      # Delete this once we are using the version with this PR: https://github.com/decidim/decidim/pull/17342 and remove all the changes included in this PR: https://github.com/AjuntamentdeBarcelona/decidim-barcelona/pull/750
+      "/lib/decidim/meetings/component.rb" => "1a89fdd79dbf48262ce8aeeec67198cd"
     }
   },
   {


### PR DESCRIPTION
#### :tophat: What? Why?

Registers a new 'meetings_attendees_count' stat on the meetings component that displays the total number of attendees in participatory spaces.

### :camera: Screenshots (optional)

<img width="1450" height="361" alt="Screenshot 2026-07-20 at 17 47 19" src="https://github.com/user-attachments/assets/b4aa09fa-facd-42df-9ced-77bb995dc347" />